### PR TITLE
Fix torture tests setup

### DIFF
--- a/src/test/java/engineering/swat/watch/APIErrorsTests.java
+++ b/src/test/java/engineering/swat/watch/APIErrorsTests.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class APIErrorsTests {
+class APIErrorsTests {
 
     private TestDirectory testDir;
 

--- a/src/test/java/engineering/swat/watch/DeleteLockTests.java
+++ b/src/test/java/engineering/swat/watch/DeleteLockTests.java
@@ -51,7 +51,7 @@ class DeleteLockTests {
     }
 
     @AfterEach
-    void cleanup() throws IOException {
+    void cleanup() {
         if (testDir != null) {
             testDir.close();
         }
@@ -61,7 +61,6 @@ class DeleteLockTests {
     static void setupEverything() {
         Awaitility.setDefaultTimeout(TestHelper.NORMAL_WAIT);
     }
-
 
     @FunctionalInterface
     private interface Deleter {

--- a/src/test/java/engineering/swat/watch/RecursiveWatchTests.java
+++ b/src/test/java/engineering/swat/watch/RecursiveWatchTests.java
@@ -31,7 +31,6 @@ import static org.awaitility.Awaitility.await;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -56,17 +55,16 @@ class RecursiveWatchTests {
     }
 
     @AfterEach
-    void cleanup() throws IOException {
+    void cleanup() {
         if (testDir != null) {
             testDir.close();
         }
     }
 
     @BeforeAll
-    static void setupEverything() throws IOException {
+    static void setupEverything() {
         Awaitility.setDefaultTimeout(TestHelper.NORMAL_WAIT);
     }
-
 
     @Test
     void newDirectoryWithFilesChangesDetected() throws IOException {
@@ -123,7 +121,7 @@ class RecursiveWatchTests {
     }
 
     @Test
-    void deleteOfFileInDirectoryShouldBeVisible() throws IOException, InterruptedException {
+    void deleteOfFileInDirectoryShouldBeVisible() throws IOException {
         var target = testDir.getTestFiles()
             .stream()
             .filter(p -> !p.getParent().equals(testDir.getTestDirectory()))

--- a/src/test/java/engineering/swat/watch/SingleDirectoryTests.java
+++ b/src/test/java/engineering/swat/watch/SingleDirectoryTests.java
@@ -30,8 +30,6 @@ import static org.awaitility.Awaitility.await;
 
 import java.io.IOException;
 import java.nio.file.Files;
-import java.time.Duration;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.awaitility.Awaitility;
@@ -42,7 +40,7 @@ import org.junit.jupiter.api.Test;
 
 import engineering.swat.watch.WatchEvent.Kind;
 
-public class SingleDirectoryTests {
+class SingleDirectoryTests {
     private TestDirectory testDir;
 
     @BeforeEach
@@ -51,7 +49,7 @@ public class SingleDirectoryTests {
     }
 
     @AfterEach
-    void cleanup() throws IOException {
+    void cleanup() {
         if (testDir != null) {
             testDir.close();
         }
@@ -63,7 +61,7 @@ public class SingleDirectoryTests {
     }
 
     @Test
-    void deleteOfFileInDirectoryShouldBeVisible() throws IOException, InterruptedException {
+    void deleteOfFileInDirectoryShouldBeVisible() throws IOException {
         var target = testDir.getTestFiles().get(0);
         var seenDelete = new AtomicBoolean(false);
         var seenCreate = new AtomicBoolean(false);
@@ -91,7 +89,7 @@ public class SingleDirectoryTests {
     }
 
     @Test
-    void alternativeAPITest() throws IOException, InterruptedException {
+    void alternativeAPITest() throws IOException {
         var target = testDir.getTestFiles().get(0);
         var seenDelete = new AtomicBoolean(false);
         var seenCreate = new AtomicBoolean(false);

--- a/src/test/java/engineering/swat/watch/SingleFileTests.java
+++ b/src/test/java/engineering/swat/watch/SingleFileTests.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class SingleFileTests {
+class SingleFileTests {
     private TestDirectory testDir;
 
     @BeforeEach
@@ -49,7 +49,7 @@ public class SingleFileTests {
     }
 
     @AfterEach
-    void cleanup() throws IOException {
+    void cleanup() {
         if (testDir != null) {
             testDir.close();
         }

--- a/src/test/java/engineering/swat/watch/SmokeTests.java
+++ b/src/test/java/engineering/swat/watch/SmokeTests.java
@@ -32,7 +32,6 @@ import static org.awaitility.Awaitility.await;
 
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.awaitility.Awaitility;
@@ -51,7 +50,7 @@ class SmokeTests {
     }
 
     @AfterEach
-    void cleanup() throws IOException {
+    void cleanup() {
         if (testDir != null) {
             testDir.close();
         }
@@ -63,7 +62,7 @@ class SmokeTests {
     }
 
     @Test
-    void watchDirectory() throws IOException, InterruptedException {
+    void watchDirectory() throws IOException {
         var changed = new AtomicBoolean(false);
         var target = testDir.getTestFiles().get(0);
         var watchConfig = Watcher.watch(testDir.getTestDirectory(), WatchScope.PATH_AND_CHILDREN)
@@ -77,7 +76,7 @@ class SmokeTests {
     }
 
     @Test
-    void watchRecursiveDirectory() throws IOException, InterruptedException {
+    void watchRecursiveDirectory() throws IOException {
         var changed = new AtomicBoolean(false);
         var target = testDir.getTestFiles().stream()
             .filter(p -> !p.getParent().equals(testDir.getTestDirectory()))
@@ -113,6 +112,4 @@ class SmokeTests {
             await("Single file change").untilTrue(changed);
         }
     }
-
-
 }

--- a/src/test/java/engineering/swat/watch/TestHelper.java
+++ b/src/test/java/engineering/swat/watch/TestHelper.java
@@ -37,7 +37,7 @@ public class TestHelper {
     static {
         var delayFactorConfig = System.getenv("DELAY_FACTOR");
         int delayFactor = delayFactorConfig == null ? 1 : Integer.parseInt(delayFactorConfig);
-        var os = System.getProperty("os", "?").toLowerCase();
+        var os = System.getProperty("os.name", "?").toLowerCase();
         if (os.contains("mac")) {
             // OSX is SLOW on it's watches
             delayFactor *= 2;

--- a/src/test/java/engineering/swat/watch/TortureTests.java
+++ b/src/test/java/engineering/swat/watch/TortureTests.java
@@ -50,7 +50,9 @@ import java.util.function.Predicate;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
@@ -63,6 +65,11 @@ class TortureTests {
     private final Logger logger = LogManager.getLogger();
 
     private TestDirectory testDir;
+
+    @BeforeAll
+    static void setupEverything() {
+        Awaitility.setDefaultTimeout(TestHelper.LONG_WAIT.getSeconds(), TimeUnit.SECONDS);
+    }
 
     @BeforeEach
     void setup() throws IOException {

--- a/src/test/java/engineering/swat/watch/TortureTests.java
+++ b/src/test/java/engineering/swat/watch/TortureTests.java
@@ -39,7 +39,6 @@ import java.util.Random;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingDeque;
@@ -58,8 +57,6 @@ import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
-import engineering.swat.watch.WatchEvent.Kind;
-
 class TortureTests {
 
     private final Logger logger = LogManager.getLogger();
@@ -77,7 +74,7 @@ class TortureTests {
     }
 
     @AfterEach
-    void cleanup() throws IOException {
+    void cleanup() {
         if (testDir != null) {
             testDir.close();
         }
@@ -97,7 +94,7 @@ class TortureTests {
             }
         }
 
-        private final static int BURST_SIZE = 1000;
+        private static final int BURST_SIZE = 1000;
 
         private void startJob(final Path root, Random r, Executor exec) {
             exec.execute(() -> {
@@ -246,7 +243,6 @@ class TortureTests {
             done.acquire(TORTURE_REGISTRATION_THREADS - 1);
             assertTrue(seen.isEmpty(), "No events should have been sent");
             var target = testDir.getTestDirectory().resolve("test124.txt");
-            //logger.info("Writing: {}", target);
             Files.writeString(target, "Hello World");
             var expected = Collections.singleton(target);
             await("We should see only one event")
@@ -331,8 +327,6 @@ class TortureTests {
 
     }
 
-
-
     @Test
     //Deletes can race the filesystem, so you might miss a few files in a dir, if that dir is already deleted
     @EnabledIfEnvironmentVariable(named="TORTURE_DELETE", matches="true")
@@ -370,7 +364,7 @@ class TortureTests {
                 });
 
             try (var activeWatch = watchConfig.start() ) {
-                logger.info("Deleting files now", THREADS);
+                logger.info("Deleting files now ({} threads)", THREADS);
                 testDir.deleteAllFiles();
                 logger.info("Waiting for the events processing to stabilize");
                 waitForStable(events, happened);

--- a/src/test/java/engineering/swat/watch/impl/BundlingTests.java
+++ b/src/test/java/engineering/swat/watch/impl/BundlingTests.java
@@ -54,7 +54,7 @@ import engineering.swat.watch.TestHelper;
 import engineering.swat.watch.impl.util.BundledSubscription;
 import engineering.swat.watch.impl.util.ISubscribable;
 
-public class BundlingTests {
+class BundlingTests {
 
     private final Logger logger = LogManager.getLogger();
     private BundledSubscription<Long, Boolean> target;
@@ -77,8 +77,7 @@ public class BundlingTests {
                 s.accept(true);
             }
         }
-    };
-
+    }
 
     @BeforeEach
     void setup() {
@@ -134,7 +133,7 @@ public class BundlingTests {
     }
 
     @RepeatedTest(failureThreshold = 1, value=50)
-    void parallelSubscriptions() throws IOException, InterruptedException {
+    void parallelSubscriptions() throws InterruptedException {
         var hits = new AtomicInteger();
         var endPointReached = new Semaphore(0);
         var waitingForClose = new Semaphore(0);
@@ -171,5 +170,4 @@ public class BundlingTests {
             .untilAtomic(hits, IsEqual.equalTo(active));
         waitingForClose.release(active);
     }
-
 }


### PR DESCRIPTION
Before this PR, **implicitly**, the `TortureTests` relied on the `BundlingTests` to be run earlier, because:
  - The `@BeforeAll` of the `BundlingTests` configured Awaitility in a way that was also needed by the `TortureTests` (setting the default timeout long enough).
  - But, the `TortureTests` didn't have its own `@BeforeAll` to do this configuration.

In earlier CI runs, coincidentally, the `BundlingTests` were indeed run before the `TortureTests`, so it all went fine. In recent CI runs, though, the order was the other way around, causing them to inexplicably fail.

This PR adds a `@BeforeAll` to the `TortureTests` to make the CI runs predicable again. This PR also fixes a few warnings to improve the code quality of the tests.