### PR TITLE
Improved overflow support: Internal `EventHandlingWatch` interface

### DIFF
--- a/src/main/java/engineering/swat/watch/ActiveWatch.java
+++ b/src/main/java/engineering/swat/watch/ActiveWatch.java
@@ -27,12 +27,32 @@
 package engineering.swat.watch;
 
 import java.io.Closeable;
+import java.nio.file.Path;
 
 /**
- * <p>Marker interface for an active watch, in the future might get properties you can inspect.</p>
+ * <p>Marker interface for an active watch, in the future might get more properties you can inspect.</p>
  *
- * <p>For now, make sure to close the watch when not interested in new events</p>
+ * <p>For now, make sure to close the watch when not interested in new events.</p>
  */
 public interface ActiveWatch extends Closeable {
 
+
+    /**
+     * Gets the path watched by this watch.
+     */
+    Path getPath();
+
+    /**
+     * Relativizes the full path of `event` against the path watched by this
+     * watch (as per `getPath()`). Returns a new event whose root path and
+     * relative path are set in accordance with the relativization.
+     */
+    default WatchEvent relativize(WatchEvent event) {
+        var fullPath = event.calculateFullPath();
+
+        var kind = event.getKind();
+        var rootPath = getPath();
+        var relativePath = rootPath.relativize(fullPath);
+        return new WatchEvent(kind, rootPath, relativePath);
+    }
 }

--- a/src/main/java/engineering/swat/watch/ActiveWatch.java
+++ b/src/main/java/engineering/swat/watch/ActiveWatch.java
@@ -36,6 +36,13 @@ import java.nio.file.Path;
  */
 public interface ActiveWatch extends Closeable {
 
+    /**
+     * Handles `event`. The purpose of this method is to trigger the event
+     * handler of this watch "from the outside" (in addition to having native
+     * file system libraries trigger the event handler "from the inside"). This
+     * is useful to report synthetic events (e.g., while handling overflows).
+     */
+    void handleEvent(WatchEvent event);
 
     /**
      * Gets the path watched by this watch.

--- a/src/main/java/engineering/swat/watch/impl/EventHandlingWatch.java
+++ b/src/main/java/engineering/swat/watch/impl/EventHandlingWatch.java
@@ -24,20 +24,32 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package engineering.swat.watch;
+package engineering.swat.watch.impl;
 
-import java.io.Closeable;
-import java.nio.file.Path;
+import engineering.swat.watch.ActiveWatch;
+import engineering.swat.watch.WatchEvent;
 
-/**
- * <p>Marker interface for an active watch, in the future might get more properties you can inspect.</p>
- *
- * <p>For now, make sure to close the watch when not interested in new events.</p>
- */
-public interface ActiveWatch extends Closeable {
+public interface EventHandlingWatch extends ActiveWatch {
 
     /**
-     * Gets the path watched by this watch.
+     * Handles `event`. The purpose of this method is to trigger the event
+     * handler of this watch "from the outside" (in addition to having native
+     * file system libraries trigger the event handler "from the inside"). This
+     * is useful to report synthetic events (e.g., while handling overflows).
      */
-    Path getPath();
+    void handleEvent(WatchEvent event);
+
+    /**
+     * Relativizes the full path of `event` against the path watched by this
+     * watch (as per `getPath()`). Returns a new event whose root path and
+     * relative path are set in accordance with the relativization.
+     */
+    default WatchEvent relativize(WatchEvent event) {
+        var fullPath = event.calculateFullPath();
+
+        var kind = event.getKind();
+        var rootPath = getPath();
+        var relativePath = rootPath.relativize(fullPath);
+        return new WatchEvent(kind, rootPath, relativePath);
+    }
 }

--- a/src/main/java/engineering/swat/watch/impl/jdk/JDKBaseWatch.java
+++ b/src/main/java/engineering/swat/watch/impl/jdk/JDKBaseWatch.java
@@ -118,4 +118,11 @@ public abstract class JDKBaseWatch implements ActiveWatch {
 
         throw new IllegalArgumentException("Unexpected watch kind: " + jdkKind);
     }
+
+    // -- ActiveWatch --
+
+    @Override
+    public Path getPath() {
+        return path;
+    }
 }

--- a/src/main/java/engineering/swat/watch/impl/jdk/JDKBaseWatch.java
+++ b/src/main/java/engineering/swat/watch/impl/jdk/JDKBaseWatch.java
@@ -122,6 +122,11 @@ public abstract class JDKBaseWatch implements ActiveWatch {
     // -- ActiveWatch --
 
     @Override
+    public void handleEvent(WatchEvent e) {
+        eventHandler.accept(e);
+    }
+
+    @Override
     public Path getPath() {
         return path;
     }

--- a/src/main/java/engineering/swat/watch/impl/jdk/JDKBaseWatch.java
+++ b/src/main/java/engineering/swat/watch/impl/jdk/JDKBaseWatch.java
@@ -37,10 +37,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import engineering.swat.watch.ActiveWatch;
 import engineering.swat.watch.WatchEvent;
+import engineering.swat.watch.impl.EventHandlingWatch;
 
-public abstract class JDKBaseWatch implements ActiveWatch {
+public abstract class JDKBaseWatch implements EventHandlingWatch {
     private final Logger logger = LogManager.getLogger();
 
     protected final Path path;
@@ -116,7 +116,7 @@ public abstract class JDKBaseWatch implements ActiveWatch {
         throw new IllegalArgumentException("Unexpected watch kind: " + jdkKind);
     }
 
-    // -- ActiveWatch --
+    // -- EventHandlingWatch --
 
     @Override
     public void handleEvent(WatchEvent e) {

--- a/src/main/java/engineering/swat/watch/impl/jdk/JDKDirectoryWatch.java
+++ b/src/main/java/engineering/swat/watch/impl/jdk/JDKDirectoryWatch.java
@@ -62,7 +62,7 @@ public class JDKDirectoryWatch extends JDKBaseWatch {
         exec.execute(() -> {
             for (var ev : events) {
                 try {
-                    eventHandler.accept(translate(ev));
+                    handleEvent(translate(ev));
                 }
                 catch (Throwable ignored) {
                     logger.error("Ignoring downstream exception:", ignored);

--- a/src/main/java/engineering/swat/watch/impl/jdk/JDKFileWatch.java
+++ b/src/main/java/engineering/swat/watch/impl/jdk/JDKFileWatch.java
@@ -73,6 +73,11 @@ public class JDKFileWatch extends JDKBaseWatch {
     // -- JDKBaseWatch --
 
     @Override
+    public void handleEvent(WatchEvent event) {
+        internal.handleEvent(event);
+    }
+
+    @Override
     public synchronized void close() throws IOException {
         internal.close();
     }

--- a/src/main/java/engineering/swat/watch/impl/jdk/JDKRecursiveDirectoryWatch.java
+++ b/src/main/java/engineering/swat/watch/impl/jdk/JDKRecursiveDirectoryWatch.java
@@ -270,7 +270,6 @@ public class JDKRecursiveDirectoryWatch extends JDKBaseWatch {
         }
     }
 
-
     private List<WatchEvent> syncAfterOverflow(Path dir) {
         var events = new ArrayList<WatchEvent>();
         var seenFiles = new HashSet<Path>();
@@ -298,6 +297,11 @@ public class JDKRecursiveDirectoryWatch extends JDKBaseWatch {
     }
 
     // -- JDKBaseWatch --
+
+    @Override
+    public void handleEvent(WatchEvent ev) {
+        processEvents(ev);
+    }
 
     @Override
     public void close() throws IOException {

--- a/src/main/java/engineering/swat/watch/impl/jdk/JDKRecursiveDirectoryWatch.java
+++ b/src/main/java/engineering/swat/watch/impl/jdk/JDKRecursiveDirectoryWatch.java
@@ -299,8 +299,8 @@ public class JDKRecursiveDirectoryWatch extends JDKBaseWatch {
     // -- JDKBaseWatch --
 
     @Override
-    public void handleEvent(WatchEvent ev) {
-        processEvents(ev);
+    public void handleEvent(WatchEvent event) {
+        processEvents(event);
     }
 
     @Override

--- a/src/test/java/engineering/swat/watch/impl/EventHandlingWatchTests.java
+++ b/src/test/java/engineering/swat/watch/impl/EventHandlingWatchTests.java
@@ -1,0 +1,67 @@
+/*
+ * BSD 2-Clause License
+ *
+ * Copyright (c) 2023, Swat.engineering
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package engineering.swat.watch.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+import engineering.swat.watch.WatchEvent;
+
+class EventHandlingWatchTests {
+
+    private static EventHandlingWatch emptyWatch(Path path) {
+        return new EventHandlingWatch() {
+            @Override
+            public void handleEvent(WatchEvent event) {
+                // Nothing to handle
+            }
+
+            @Override
+            public void close() throws IOException {
+                // Nothing to close
+            }
+
+            @Override
+            public Path getPath() {
+                return path;
+            }
+        };
+    }
+
+    @Test
+    void relativizeTest() {
+        var e1 = new WatchEvent(WatchEvent.Kind.OVERFLOW, Path.of("foo"), Path.of("bar", "baz.txt"));
+        var e2 = new WatchEvent(WatchEvent.Kind.OVERFLOW, Path.of("foo", "bar", "baz.txt"));
+        var e3 = emptyWatch(Path.of("foo")).relativize(e2);
+        assertEquals(e1.getRootPath(), e3.getRootPath());
+        assertEquals(e1.getRelativePath(), e3.getRelativePath());
+    }
+}


### PR DESCRIPTION
This PR adds a new internal interface, `EventHandlingWatch`, which extends the existing external interface `ActiveWatch`. In the next PRs, `EventHandlingWatch` will be generically used as a type in overflow event handlers instead of `JDK...Watch`. That's useful because these overflow handlers may also be used by non-JDK watches.