### PR TITLE
Improved overflow support: Internal event handlers can dispatch new events

### DIFF
--- a/src/main/java/engineering/swat/watch/Watcher.java
+++ b/src/main/java/engineering/swat/watch/Watcher.java
@@ -38,6 +38,7 @@ import java.util.function.Consumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import engineering.swat.watch.impl.EventHandlingWatch;
 import engineering.swat.watch.impl.jdk.JDKDirectoryWatch;
 import engineering.swat.watch.impl.jdk.JDKFileWatch;
 import engineering.swat.watch.impl.jdk.JDKRecursiveDirectoryWatch;
@@ -55,8 +56,8 @@ public class Watcher {
     private final Path path;
     private volatile Executor executor = CompletableFuture::runAsync;
 
-    private static final BiConsumer<ActiveWatch, WatchEvent> EMPTY_HANDLER = (w, e) -> {};
-    private volatile BiConsumer<ActiveWatch, WatchEvent> eventHandler = EMPTY_HANDLER;
+    private static final BiConsumer<EventHandlingWatch, WatchEvent> EMPTY_HANDLER = (w, e) -> {};
+    private volatile BiConsumer<EventHandlingWatch, WatchEvent> eventHandler = EMPTY_HANDLER;
 
 
     private Watcher(WatchScope scope, Path path) {

--- a/src/main/java/engineering/swat/watch/impl/jdk/JDKBaseWatch.java
+++ b/src/main/java/engineering/swat/watch/impl/jdk/JDKBaseWatch.java
@@ -45,10 +45,10 @@ public abstract class JDKBaseWatch implements EventHandlingWatch {
 
     protected final Path path;
     protected final Executor exec;
-    protected final BiConsumer<ActiveWatch, WatchEvent> eventHandler;
+    protected final BiConsumer<EventHandlingWatch, WatchEvent> eventHandler;
     protected final AtomicBoolean started = new AtomicBoolean();
 
-    protected JDKBaseWatch(Path path, Executor exec, BiConsumer<ActiveWatch, WatchEvent> eventHandler) {
+    protected JDKBaseWatch(Path path, Executor exec, BiConsumer<EventHandlingWatch, WatchEvent> eventHandler) {
         this.path = path;
         this.exec = exec;
         this.eventHandler = eventHandler;

--- a/src/main/java/engineering/swat/watch/impl/jdk/JDKBaseWatch.java
+++ b/src/main/java/engineering/swat/watch/impl/jdk/JDKBaseWatch.java
@@ -31,7 +31,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardWatchEventKinds;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -45,10 +45,10 @@ public abstract class JDKBaseWatch implements ActiveWatch {
 
     protected final Path path;
     protected final Executor exec;
-    protected final Consumer<WatchEvent> eventHandler;
+    protected final BiConsumer<ActiveWatch, WatchEvent> eventHandler;
     protected final AtomicBoolean started = new AtomicBoolean();
 
-    protected JDKBaseWatch(Path path, Executor exec, Consumer<WatchEvent> eventHandler) {
+    protected JDKBaseWatch(Path path, Executor exec, BiConsumer<ActiveWatch, WatchEvent> eventHandler) {
         this.path = path;
         this.exec = exec;
         this.eventHandler = eventHandler;
@@ -123,7 +123,7 @@ public abstract class JDKBaseWatch implements ActiveWatch {
 
     @Override
     public void handleEvent(WatchEvent e) {
-        eventHandler.accept(e);
+        eventHandler.accept(this, e);
     }
 
     @Override

--- a/src/main/java/engineering/swat/watch/impl/jdk/JDKDirectoryWatch.java
+++ b/src/main/java/engineering/swat/watch/impl/jdk/JDKDirectoryWatch.java
@@ -31,12 +31,13 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.Executor;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
+import engineering.swat.watch.ActiveWatch;
 import engineering.swat.watch.WatchEvent;
 import engineering.swat.watch.impl.util.BundledSubscription;
 import engineering.swat.watch.impl.util.SubscriptionKey;
@@ -49,11 +50,11 @@ public class JDKDirectoryWatch extends JDKBaseWatch {
     private static final BundledSubscription<SubscriptionKey, List<java.nio.file.WatchEvent<?>>>
         BUNDLED_JDK_WATCHERS = new BundledSubscription<>(JDKPoller::register);
 
-    public JDKDirectoryWatch(Path directory, Executor exec, Consumer<WatchEvent> eventHandler) {
+    public JDKDirectoryWatch(Path directory, Executor exec, BiConsumer<ActiveWatch, WatchEvent> eventHandler) {
         this(directory, exec, eventHandler, false);
     }
 
-    public JDKDirectoryWatch(Path directory, Executor exec, Consumer<WatchEvent> eventHandler, boolean nativeRecursive) {
+    public JDKDirectoryWatch(Path directory, Executor exec, BiConsumer<ActiveWatch, WatchEvent> eventHandler, boolean nativeRecursive) {
         super(directory, exec, eventHandler);
         this.nativeRecursive = nativeRecursive;
     }

--- a/src/main/java/engineering/swat/watch/impl/jdk/JDKDirectoryWatch.java
+++ b/src/main/java/engineering/swat/watch/impl/jdk/JDKDirectoryWatch.java
@@ -37,8 +37,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
-import engineering.swat.watch.ActiveWatch;
 import engineering.swat.watch.WatchEvent;
+import engineering.swat.watch.impl.EventHandlingWatch;
 import engineering.swat.watch.impl.util.BundledSubscription;
 import engineering.swat.watch.impl.util.SubscriptionKey;
 
@@ -50,11 +50,11 @@ public class JDKDirectoryWatch extends JDKBaseWatch {
     private static final BundledSubscription<SubscriptionKey, List<java.nio.file.WatchEvent<?>>>
         BUNDLED_JDK_WATCHERS = new BundledSubscription<>(JDKPoller::register);
 
-    public JDKDirectoryWatch(Path directory, Executor exec, BiConsumer<ActiveWatch, WatchEvent> eventHandler) {
+    public JDKDirectoryWatch(Path directory, Executor exec, BiConsumer<EventHandlingWatch, WatchEvent> eventHandler) {
         this(directory, exec, eventHandler, false);
     }
 
-    public JDKDirectoryWatch(Path directory, Executor exec, BiConsumer<ActiveWatch, WatchEvent> eventHandler, boolean nativeRecursive) {
+    public JDKDirectoryWatch(Path directory, Executor exec, BiConsumer<EventHandlingWatch, WatchEvent> eventHandler, boolean nativeRecursive) {
         super(directory, exec, eventHandler);
         this.nativeRecursive = nativeRecursive;
     }

--- a/src/main/java/engineering/swat/watch/impl/jdk/JDKFileWatch.java
+++ b/src/main/java/engineering/swat/watch/impl/jdk/JDKFileWatch.java
@@ -35,8 +35,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import engineering.swat.watch.ActiveWatch;
 import engineering.swat.watch.WatchEvent;
+import engineering.swat.watch.impl.EventHandlingWatch;
 
 /**
  * It's not possible to monitor a single file (or directory), so we have to find a directory watcher, and connect to that
@@ -47,7 +47,7 @@ public class JDKFileWatch extends JDKBaseWatch {
     private final Logger logger = LogManager.getLogger();
     private final JDKBaseWatch internal;
 
-    public JDKFileWatch(Path file, Executor exec, BiConsumer<ActiveWatch, WatchEvent> eventHandler) {
+    public JDKFileWatch(Path file, Executor exec, BiConsumer<EventHandlingWatch, WatchEvent> eventHandler) {
         super(file, exec, eventHandler);
 
         var message = "The root path is not a valid path for a file watch";

--- a/src/main/java/engineering/swat/watch/impl/jdk/JDKFileWatch.java
+++ b/src/main/java/engineering/swat/watch/impl/jdk/JDKFileWatch.java
@@ -29,12 +29,13 @@ package engineering.swat.watch.impl.jdk;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.concurrent.Executor;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import engineering.swat.watch.ActiveWatch;
 import engineering.swat.watch.WatchEvent;
 
 /**
@@ -46,7 +47,7 @@ public class JDKFileWatch extends JDKBaseWatch {
     private final Logger logger = LogManager.getLogger();
     private final JDKBaseWatch internal;
 
-    public JDKFileWatch(Path file, Executor exec, Consumer<WatchEvent> eventHandler) {
+    public JDKFileWatch(Path file, Executor exec, BiConsumer<ActiveWatch, WatchEvent> eventHandler) {
         super(file, exec, eventHandler);
 
         var message = "The root path is not a valid path for a file watch";
@@ -54,9 +55,9 @@ public class JDKFileWatch extends JDKBaseWatch {
         var fileName = requireNonNull(file.getFileName(), message);
         assert !parent.equals(file);
 
-        this.internal = new JDKDirectoryWatch(parent, exec, e -> {
+        this.internal = new JDKDirectoryWatch(parent, exec, (w, e) -> {
             if (fileName.equals(e.getRelativePath())) {
-                eventHandler.accept(e);
+                eventHandler.accept(w, e);
             }
         });
 

--- a/src/main/java/engineering/swat/watch/impl/jdk/JDKRecursiveDirectoryWatch.java
+++ b/src/main/java/engineering/swat/watch/impl/jdk/JDKRecursiveDirectoryWatch.java
@@ -42,24 +42,25 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import engineering.swat.watch.ActiveWatch;
 import engineering.swat.watch.WatchEvent;
 
 public class JDKRecursiveDirectoryWatch extends JDKBaseWatch {
     private final Logger logger = LogManager.getLogger();
     private final ConcurrentMap<Path, JDKDirectoryWatch> activeWatches = new ConcurrentHashMap<>();
 
-    public JDKRecursiveDirectoryWatch(Path directory, Executor exec, Consumer<WatchEvent> eventHandler) {
+    public JDKRecursiveDirectoryWatch(Path directory, Executor exec, BiConsumer<ActiveWatch, WatchEvent> eventHandler) {
         super(directory, exec, eventHandler);
     }
 
     private void processEvents(WatchEvent ev) {
         logger.trace("Forwarding event: {}", ev);
-        eventHandler.accept(ev);
+        eventHandler.accept(this, ev);
         logger.trace("Unwrapping event: {}", ev);
         switch (ev.getKind()) {
             case CREATED: handleCreate(ev); break;
@@ -71,9 +72,8 @@ public class JDKRecursiveDirectoryWatch extends JDKBaseWatch {
 
     private void publishExtraEvents(List<WatchEvent> ev) {
         logger.trace("Reporting new nested directories & files: {}", ev);
-        ev.forEach(eventHandler);
+        ev.forEach(e -> eventHandler.accept(this, e));
     }
-
 
     private void handleCreate(WatchEvent ev) {
         // between the event and the current state of the file system
@@ -161,9 +161,9 @@ public class JDKRecursiveDirectoryWatch extends JDKBaseWatch {
         }
 
         /** Make sure that the events are relative to the actual root of the recursive watch */
-        private Consumer<WatchEvent> relocater(Path subRoot) {
+        private BiConsumer<ActiveWatch, WatchEvent> relocater(Path subRoot) {
             final Path newRelative = path.relativize(subRoot);
-            return ev -> {
+            return (w, ev) -> {
                 var rewritten = new WatchEvent(ev.getKind(), path, newRelative.resolve(ev.getRelativePath()));
                 processEvents(rewritten);
             };

--- a/src/main/java/engineering/swat/watch/impl/jdk/JDKRecursiveDirectoryWatch.java
+++ b/src/main/java/engineering/swat/watch/impl/jdk/JDKRecursiveDirectoryWatch.java
@@ -47,14 +47,14 @@ import java.util.function.BiConsumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import engineering.swat.watch.ActiveWatch;
 import engineering.swat.watch.WatchEvent;
+import engineering.swat.watch.impl.EventHandlingWatch;
 
 public class JDKRecursiveDirectoryWatch extends JDKBaseWatch {
     private final Logger logger = LogManager.getLogger();
     private final ConcurrentMap<Path, JDKDirectoryWatch> activeWatches = new ConcurrentHashMap<>();
 
-    public JDKRecursiveDirectoryWatch(Path directory, Executor exec, BiConsumer<ActiveWatch, WatchEvent> eventHandler) {
+    public JDKRecursiveDirectoryWatch(Path directory, Executor exec, BiConsumer<EventHandlingWatch, WatchEvent> eventHandler) {
         super(directory, exec, eventHandler);
     }
 
@@ -161,7 +161,7 @@ public class JDKRecursiveDirectoryWatch extends JDKBaseWatch {
         }
 
         /** Make sure that the events are relative to the actual root of the recursive watch */
-        private BiConsumer<ActiveWatch, WatchEvent> relocater(Path subRoot) {
+        private BiConsumer<EventHandlingWatch, WatchEvent> relocater(Path subRoot) {
             final Path newRelative = path.relativize(subRoot);
             return (w, ev) -> {
                 var rewritten = new WatchEvent(ev.getKind(), path, newRelative.resolve(ev.getRelativePath()));


### PR DESCRIPTION
#### What

This PR generalizes the signature of internal event handlers from `Consumer<WatchEvent>` to `BiConsumer<EventHandlingWatch, WatchEvent>`. Thus, when internal event handlers are called, they also get access to the watch that dispatched the event.

This change affects only the internals of the library (currently only the `JDK...Watch` classes, but later also the macOS code). The end-user API still expects `Consumer<WatchEvent>` (or `WatchEventListener`).

#### Why

Imagine an overflow event happens, so the directory needs to be rescanned. Before this PR, the event handler of the watch could look something like this (simplified code, just to make the point):

```java
class FooWatch implements EventHandlingWatch {

  ...

  @override
  public void handleEvent(WatchEvent event) {
    if (event.getKind() == WatchEvent.Kind.OVERFLOW) {
      var events = rescanDirectory(); // Returns a collection of rescanning events (CREATED or MODIFIED)
      for (var e : events) {
        // Recursively call this method for each of the rescanning events
        handleEvent(e);
      }
    }

    // Run the user-defined event handler
    this.eventHandler.accept(event);
  }
}
```

The point is that, to auto-handle overflow events, the auto-handler must access a watch to dispatch rescanning events (i.e., call the watch's `handleEvent` method). There are several alternatives to achieve this, including:

 1. Define auto-handlers **inside** the watch class -- This is essentially what currently happens in `JDKRecursiveDirectoryWatch`
 2. Define auto-handlers **outside** the watch class; pass a watch class reference when the auto-handler is **constructed**
 3. Define auto-handlers **outside** the watch class; pass a watch class reference when the auto-handler is **called**

The problem with alternative 1 is that each auto-handler class should be usable with multiple watch classes (otherwise, we're potentially duplicating a lot of code). The problem with alternative 2 is that each auto-handler instance should be usable with multiple watch instances (otherwise, we're potentially duplicating a lot of handler objects that do essentially the same thing).

Thus, this PR implements alternative 3. It enables:
  - Defining auto-handler code completely independent of the watch classes (as long as they implement the `EventHandlingWatch` interface, which has method `handleEvent`)
  - Construct a single auto-handler that can be (re)used by multiple watches

(Usages of these features are demonstrated in the next PR.)