### PR TITLE
Improved overflow support: Indexing rescanner

### DIFF
--- a/src/main/java/engineering/swat/watch/Watcher.java
+++ b/src/main/java/engineering/swat/watch/Watcher.java
@@ -42,6 +42,7 @@ import engineering.swat.watch.impl.EventHandlingWatch;
 import engineering.swat.watch.impl.jdk.JDKDirectoryWatch;
 import engineering.swat.watch.impl.jdk.JDKFileWatch;
 import engineering.swat.watch.impl.jdk.JDKRecursiveDirectoryWatch;
+import engineering.swat.watch.impl.overflows.IndexingRescanner;
 import engineering.swat.watch.impl.overflows.MemorylessRescanner;
 
 /**
@@ -213,6 +214,8 @@ public class Watcher {
                 return eventHandler;
             case ALL:
                 return new MemorylessRescanner(executor).andThen(eventHandler);
+            case DIRTY:
+                return new IndexingRescanner(executor, path, scope).andThen(eventHandler);
             default:
                 throw new UnsupportedOperationException("No event handler has been defined yet for this overflow policy");
         }

--- a/src/main/java/engineering/swat/watch/Watcher.java
+++ b/src/main/java/engineering/swat/watch/Watcher.java
@@ -215,7 +215,7 @@ public class Watcher {
             case ALL:
                 return new MemorylessRescanner(executor).andThen(eventHandler);
             case DIRTY:
-                return new IndexingRescanner(executor, path, scope).andThen(eventHandler);
+                return eventHandler.andThen(new IndexingRescanner(executor, path, scope));
             default:
                 throw new UnsupportedOperationException("No event handler has been defined yet for this overflow policy");
         }

--- a/src/main/java/engineering/swat/watch/impl/overflows/BaseFileVisitor.java
+++ b/src/main/java/engineering/swat/watch/impl/overflows/BaseFileVisitor.java
@@ -1,0 +1,88 @@
+/*
+ * BSD 2-Clause License
+ *
+ * Copyright (c) 2023, Swat.engineering
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package engineering.swat.watch.impl.overflows;
+
+import java.io.IOException;
+import java.nio.file.FileVisitOption;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.util.EnumSet;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import engineering.swat.watch.WatchEvent;
+import engineering.swat.watch.WatchScope;
+
+/**
+ * Base extension of {@link SimpleFileVisitor}, intended to be further
+ * specialized by subclasses to auto-handle {@link WatchEvent.Kind#OVERFLOW}
+ * events. In particular, method {@link #walkFileTree} of this class internally
+ * calls {@link Files#walkFileTree} to visit the file tree that starts at
+ * {@link #path}, with a maximum depth inferred from {@link #scope}. Subclasses
+ * can be specialized, for instance, to generate synthetic events or index a
+ * file tree.
+ */
+public class BaseFileVisitor extends SimpleFileVisitor<Path> {
+    private final Logger logger = LogManager.getLogger();
+
+    protected final Path path;
+    protected final WatchScope scope;
+
+    public BaseFileVisitor(Path path, WatchScope scope) {
+        this.path = path;
+        this.scope = scope;
+    }
+
+    public void walkFileTree() {
+        var options = EnumSet.noneOf(FileVisitOption.class);
+        var maxDepth = scope == WatchScope.PATH_AND_ALL_DESCENDANTS ? Integer.MAX_VALUE : 1;
+        try {
+            Files.walkFileTree(path, options, maxDepth, this);
+        } catch (IOException e) {
+            logger.error("Could not walk: {} ({})", path, e);
+        }
+    }
+
+    // -- SimpleFileVisitor --
+
+    @Override
+    public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+        logger.error("Could not walk regular file: {} ({})", file, exc);
+        return FileVisitResult.CONTINUE;
+    }
+
+    @Override
+    public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+        if (exc != null) {
+            logger.error("Could not walk directory: {} ({})", dir, exc);
+        }
+        return FileVisitResult.CONTINUE;
+    }
+}

--- a/src/main/java/engineering/swat/watch/impl/overflows/BaseFileVisitor.java
+++ b/src/main/java/engineering/swat/watch/impl/overflows/BaseFileVisitor.java
@@ -51,7 +51,6 @@ import engineering.swat.watch.WatchScope;
  */
 public class BaseFileVisitor extends SimpleFileVisitor<Path> {
     private final Logger logger = LogManager.getLogger();
-
     protected final Path path;
     protected final WatchScope scope;
 

--- a/src/main/java/engineering/swat/watch/impl/overflows/IndexingRescanner.java
+++ b/src/main/java/engineering/swat/watch/impl/overflows/IndexingRescanner.java
@@ -1,0 +1,137 @@
+/*
+ * BSD 2-Clause License
+ *
+ * Copyright (c) 2023, Swat.engineering
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package engineering.swat.watch.impl.overflows;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import engineering.swat.watch.WatchEvent;
+import engineering.swat.watch.WatchScope;
+import engineering.swat.watch.impl.EventHandlingWatch;
+
+public class IndexingRescanner extends MemorylessRescanner {
+    private final Logger logger = LogManager.getLogger();
+    private final Map<Path, FileTime> index = new ConcurrentHashMap<>();
+
+    public IndexingRescanner(Executor exec, Path path, WatchScope scope) {
+        super(exec);
+        rescan(path, scope); // Make an initial scan to populate the index
+    }
+
+    // -- MemorylessRescanner --
+
+    @Override
+    protected MemorylessRescanner.FileVisitor newFileVisitor() {
+        return new FileVisitor();
+    }
+
+    protected class FileVisitor extends MemorylessRescanner.FileVisitor {
+        private Set<Path> visited = new HashSet<>();
+
+        @Override
+        protected void addEvents(Path path, BasicFileAttributes attrs) {
+            visited.add(path);
+            var lastModifiedTimeOld = index.get(path);
+            var lastModifiedTimeNew = attrs.lastModifiedTime();
+
+            // The path isn't indexed yet
+            if (lastModifiedTimeOld == null) {
+                index.put(path, lastModifiedTimeNew);
+                super.addEvents(path, attrs);
+            }
+
+            // The path is already indexed, and the old last-modified-time is
+            // strictly before the new-last-modified-time
+            else if (lastModifiedTimeOld.compareTo(lastModifiedTimeNew) < 0) {
+                index.put(path, lastModifiedTimeNew);
+                events.add(new WatchEvent(WatchEvent.Kind.MODIFIED, path));
+            }
+        }
+
+        @Override
+        public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+            // If the visitor is back at the start, then the time is right to
+            // issue `DELETED` events based on the set of `visited` paths.
+            if (dir.equals(start)) {
+                var i = index.keySet().iterator();
+                while (i.hasNext()) {
+                    var p = i.next();
+                    if (p.startsWith(start) && !visited.contains(p)) {
+                        events.add(new WatchEvent(WatchEvent.Kind.DELETED, p));
+                        i.remove(); // Remove `p` from `index`
+                    }
+                }
+            }
+
+            return super.postVisitDirectory(dir, exc);
+        }
+    }
+
+    @Override
+    public void accept(EventHandlingWatch watch, WatchEvent event) {
+        var fullPath = event.calculateFullPath();
+        switch (event.getKind()) {
+
+            case MODIFIED:
+                // If a modified event happens for a path that's not in the
+                // index yet, then a create event might have been missed.
+                if (!index.containsKey(fullPath)) {
+                    var created = new WatchEvent(WatchEvent.Kind.CREATED, fullPath);
+                    watch.handleEvent(created);
+                }
+                // Fallthrough intended
+
+            case CREATED:
+                try {
+                    index.put(fullPath, Files.getLastModifiedTime(fullPath));
+                } catch (IOException e) {
+                    logger.error("Could not get modification time of: {} ({})", fullPath, e);
+                }
+                break;
+
+            case DELETED:
+                index.remove(fullPath);
+                break;
+
+            case OVERFLOW:
+                super.accept(watch, event);
+                break;
+        }
+    }
+}

--- a/src/main/java/engineering/swat/watch/impl/overflows/IndexingRescanner.java
+++ b/src/main/java/engineering/swat/watch/impl/overflows/IndexingRescanner.java
@@ -117,12 +117,9 @@ public class IndexingRescanner extends MemorylessRescanner {
             // is right to issue `DELETED` events based on the set of `visited`
             // paths.
             if (dir.equals(path)) {
-                var i = index.keySet().iterator();
-                while (i.hasNext()) {
-                    var p = i.next();
+                for (var p : index.keySet()) {
                     if (p.startsWith(path) && !visited.contains(p)) {
                         events.add(new WatchEvent(WatchEvent.Kind.DELETED, p));
-                        i.remove(); // Remove `p` from `index`
                     }
                 }
             }
@@ -130,7 +127,7 @@ public class IndexingRescanner extends MemorylessRescanner {
         }
     }
 
-    // -- MemorylessRescanner
+    // -- MemorylessRescanner --
 
     @Override
     public void accept(EventHandlingWatch watch, WatchEvent event) {

--- a/src/main/java/engineering/swat/watch/impl/overflows/IndexingRescanner.java
+++ b/src/main/java/engineering/swat/watch/impl/overflows/IndexingRescanner.java
@@ -77,7 +77,7 @@ public class IndexingRescanner extends MemorylessRescanner {
             }
 
             // The path is already indexed, and the old last-modified-time is
-            // strictly before the new-last-modified-time
+            // strictly before the new last-modified-time
             else if (lastModifiedTimeOld.compareTo(lastModifiedTimeNew) < 0) {
                 index.put(path, lastModifiedTimeNew);
                 events.add(new WatchEvent(WatchEvent.Kind.MODIFIED, path));

--- a/src/main/java/engineering/swat/watch/impl/overflows/MemorylessRescanner.java
+++ b/src/main/java/engineering/swat/watch/impl/overflows/MemorylessRescanner.java
@@ -93,7 +93,7 @@ public class MemorylessRescanner implements BiConsumer<EventHandlingWatch, Watch
             return events;
         }
 
-        protected void addEvents(Path path, BasicFileAttributes attrs) {
+        protected void generateEvents(Path path, BasicFileAttributes attrs) {
             events.add(new WatchEvent(WatchEvent.Kind.CREATED, path));
             if (attrs.isRegularFile() && attrs.size() > 0) {
                 events.add(new WatchEvent(WatchEvent.Kind.MODIFIED, path));
@@ -107,14 +107,14 @@ public class MemorylessRescanner implements BiConsumer<EventHandlingWatch, Watch
             if (start == null) {
                 start = dir;
             } else {
-                addEvents(dir, attrs);
+                generateEvents(dir, attrs);
             }
             return FileVisitResult.CONTINUE;
         }
 
         @Override
         public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-            addEvents(file, attrs);
+            generateEvents(file, attrs);
             return FileVisitResult.CONTINUE;
         }
 

--- a/src/main/java/engineering/swat/watch/impl/overflows/MemorylessRescanner.java
+++ b/src/main/java/engineering/swat/watch/impl/overflows/MemorylessRescanner.java
@@ -65,6 +65,10 @@ public class MemorylessRescanner implements BiConsumer<EventHandlingWatch, Watch
     }
 
     protected class Generator extends BaseFileVisitor {
+        // When this class is used as intended, `events` is accessed only by one
+        // thread (the one that executes `Files.walkFileTree` via
+        // `BaseFileVisitor.walkFileTree`), so no additional thread-safety
+        // measures are needed to protect it from concurrent accesses.
         protected final List<WatchEvent> events = new ArrayList<>();
 
         public Generator(Path path, WatchScope scope) {

--- a/src/test/java/engineering/swat/watch/SingleDirectoryTests.java
+++ b/src/test/java/engineering/swat/watch/SingleDirectoryTests.java
@@ -225,7 +225,7 @@ class SingleDirectoryTests {
 
             var overflow = new WatchEvent(WatchEvent.Kind.OVERFLOW, directory);
             ((EventHandlingWatch) watch).handleEvent(overflow);
-            Thread.sleep(TestHelper.NORMAL_WAIT.toMillis());
+            Thread.sleep(TestHelper.LONG_WAIT.toMillis());
             // At this point, the current thread has presumably slept long
             // enough for the `OVERFLOW` event to have been handled by the
             // rescanner. This means that synthetic events must have been issued

--- a/src/test/java/engineering/swat/watch/SingleDirectoryTests.java
+++ b/src/test/java/engineering/swat/watch/SingleDirectoryTests.java
@@ -206,6 +206,7 @@ class SingleDirectoryTests {
             });
 
         try (var watch = watchConfig.start()) {
+            Thread.sleep(TestHelper.NORMAL_WAIT.toMillis());
             // At this point, the index of last-modified-times inside `watch` is
             // populated with initial values.
 
@@ -213,6 +214,7 @@ class SingleDirectoryTests {
             Files.writeString(directory.resolve("b.txt"), "bar");
             Files.delete(directory.resolve("c.txt"));
             Files.createFile(directory.resolve("d.txt"));
+            Thread.sleep(TestHelper.NORMAL_WAIT.toMillis());
             // At this point, regular events have been generated for a.txt,
             // b.txt, c.txt, and d.txt by the file system. These events won't be
             // handled by `watch` just yet, though, because the semaphore is


### PR DESCRIPTION
This PR implements the generation of synthetic `CREATED`/`MODIFIED`/`DELETED` events for `DIRTY` files to auto-handle overflow events. There are two new classes: `IndexingRescanner` and `BaseFileVisitor`. To conveniently reuse some of the functionality of `MemorylessRescanner`, there are refactoring-kind-of changes in that class, too.