### PR TITLE
Improved overflow support: Parameterized torture tests

### DIFF
--- a/src/main/java/engineering/swat/watch/impl/overflows/IndexingRescanner.java
+++ b/src/main/java/engineering/swat/watch/impl/overflows/IndexingRescanner.java
@@ -141,7 +141,10 @@ public class IndexingRescanner extends MemorylessRescanner {
             var visitedInDir = visited.pop();
             if (visitedInDir != null) {
                 for (var p : index.keySet()) {
-                    if (dir.equals(p.getParent()) && !visitedInDir.contains(p)) {
+                    if (dir.equals(p.getParent()) && !visitedInDir.contains(p) && !Files.exists(p)) {
+                        // Note: The third subcondition is needed because the
+                        // index may have been updated during the visit. In that
+                        // case, `p` might not be in `visitedInDir`, but exist.
                         events.add(new WatchEvent(WatchEvent.Kind.DELETED, p));
                     }
                 }

--- a/src/main/java/engineering/swat/watch/impl/overflows/IndexingRescanner.java
+++ b/src/main/java/engineering/swat/watch/impl/overflows/IndexingRescanner.java
@@ -185,12 +185,11 @@ public class IndexingRescanner extends MemorylessRescanner {
     }
 
     protected class Generator extends MemorylessRescanner.Generator {
-        // Field to keep track of (a stack of sets, of file names, of) the paths
-        // that are visited during the current rescan (one frame for each nested
-        // subdirectory), to approximate `DELETED` events that happened since
-        // the previous rescan. Instances of this class are supposed to be used
-        // non-concurrently, so no synchronization to access this field is
-        // needed.
+        // Field to keep track of (a stack of) the paths that are visited during
+        // the current rescan (one frame for each nested subdirectory), to
+        // approximate `DELETED` events that happened since the previous rescan.
+        // Instances of this class are supposed to be used non-concurrently, so
+        // no synchronization to access this field is needed.
         private final Deque<Set<Path>> visited = new ArrayDeque<>();
 
         public Generator(Path path, WatchScope scope) {

--- a/src/main/java/engineering/swat/watch/impl/overflows/IndexingRescanner.java
+++ b/src/main/java/engineering/swat/watch/impl/overflows/IndexingRescanner.java
@@ -73,7 +73,7 @@ public class IndexingRescanner extends MemorylessRescanner {
         }
 
         public Set<Path> getParents() {
-            return values.keySet();
+            return (Set<Path>) values.keySet();
         }
 
         public Set<Path> getFileNames(Path parent) {
@@ -85,7 +85,7 @@ public class IndexingRescanner extends MemorylessRescanner {
             return apply(this::remove, p);
         }
 
-        private V apply(BiFunction<Path, Path, V> action, Path p) {
+        private @Nullable V apply(BiFunction<Path, Path, @Nullable V> action, Path p) {
             var parent = p.getParent();
             var fileName = p.getFileName();
             if (parent != null && fileName != null) {

--- a/src/main/java/engineering/swat/watch/impl/overflows/IndexingRescanner.java
+++ b/src/main/java/engineering/swat/watch/impl/overflows/IndexingRescanner.java
@@ -73,12 +73,12 @@ public class IndexingRescanner extends MemorylessRescanner {
         }
 
         public Set<Path> getParents() {
-            return (Set<Path>) values.keySet();
+            return (Set<Path>) values.keySet(); // Cast for Checker Framework
         }
 
         public Set<Path> getFileNames(Path parent) {
             var inner = values.get(parent);
-            return inner == null ? Collections.emptySet() : (Set<Path>) inner.keySet();
+            return inner == null ? Collections.emptySet() : (Set<Path>) inner.keySet(); // Cast for Checker Framework
         }
 
         public @Nullable V remove(Path p) {
@@ -247,7 +247,7 @@ public class IndexingRescanner extends MemorylessRescanner {
                         var fullPath = dir.resolve(p);
                         // The index may have been updated during the visit, so
                         // even if `p` isn't contained in `visitedInDir`, by
-                        // now, it might have come into existance.
+                        // now, it may have come into existence.
                         if (!Files.exists(fullPath)) {
                             events.add(new WatchEvent(WatchEvent.Kind.DELETED, fullPath));
                         }

--- a/src/test/java/engineering/swat/watch/TestHelper.java
+++ b/src/test/java/engineering/swat/watch/TestHelper.java
@@ -27,6 +27,9 @@
 package engineering.swat.watch;
 
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 public class TestHelper {
 
@@ -53,5 +56,22 @@ public class TestHelper {
         SHORT_WAIT = Duration.ofSeconds(1 * delayFactor);
         NORMAL_WAIT = Duration.ofSeconds(4 * delayFactor);
         LONG_WAIT = Duration.ofSeconds(8 * delayFactor);
+    }
+
+    public static <T> Stream<T> streamOf(T[] values, int repetitions) {
+        return streamOf(values, repetitions, false);
+    }
+
+    public static <T> Stream<T> streamOf(T[] values, int repetitions, boolean sortByRepetition) {
+        if (sortByRepetition) {
+            return IntStream
+                .range(0, repetitions)
+                .boxed()
+                .flatMap(i -> Arrays.stream(values));
+        }
+        else { // Sort by value
+            return Arrays.stream(values).flatMap(v ->
+                IntStream.range(0, repetitions).mapToObj(i -> v));
+        }
     }
 }

--- a/src/test/java/engineering/swat/watch/TortureTests.java
+++ b/src/test/java/engineering/swat/watch/TortureTests.java
@@ -54,6 +54,7 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -209,14 +210,8 @@ class TortureTests {
 
     private final int TORTURE_REGISTRATION_THREADS = THREADS * 500;
 
-    static Stream<OnOverflow> manyRegistrationsForSamePathSource() {
-        OnOverflow[] values = { OnOverflow.ALL, OnOverflow.DIRTY };
-        return TestHelper.streamOf(values, 5);
-    }
-
-    @ParameterizedTest
-    @MethodSource("manyRegistrationsForSamePathSource")
-    void manyRegistrationsForSamePath(OnOverflow whichFiles) throws InterruptedException, IOException {
+    @RepeatedTest(failureThreshold=1, value = 20)
+    void manyRegistrationsForSamePath() throws InterruptedException, IOException {
         var startRegistering = new Semaphore(0);
         var startedWatching = new Semaphore(0);
         var startDeregistring = new Semaphore(0);
@@ -229,7 +224,6 @@ class TortureTests {
                 try {
                     var watcher = Watcher
                         .watch(testDir.getTestDirectory(), WatchScope.PATH_AND_CHILDREN)
-                        .approximate(whichFiles)
                         .on(e -> seen.add(e.calculateFullPath()));
                     startRegistering.acquire();
                     try (var c = watcher.start()) {


### PR DESCRIPTION
### Primary goal of this PR

This PR parameterizes the torture tests with auto-handlers for `OVERFLOW` events, so we now automatically run all torture tests with `MemorylessRescanner` (i.e., `OnOverflow.ALL`) and `IndexingRescanner` (i.e., `OnOverflow.DIRTY`).

As JUnit [doesn't](https://github.com/junit-team/junit5/issues/1224) seem to have easy support for combining `@ParameterizedTest` and `@RepeatedTest`, but we do need both, three approaches were considered:

  - Implement our own test template that combines them, as demonstrated [here](https://stackoverflow.com/questions/66139122)
  - Use [containers](https://github.com/junit-team/junit5/issues/871)
  - Provide a stream of repeated input values to [instantiate the test parameter](https://junit.org/junit5/docs/current/user-guide/#writing-tests-parameterized-tests-sources-MethodSource)

This PR implements the third approach because: (a) it's conceptually easy; (b) it yields the least amount of extra code; (c) as a result, it seems to strike the best balance for now between effort vs. number of torture tests that need it (only one). If, at some point in the future, we happen to have many more (torture) tests that need it, then maybe we should revisit and invest some effort to use one of the other approaches.

### Other changes

This PR also fixes two issues in `IndexingRescanner` that were revealed by the parameterized tests, namely: (a) a small fix that makes sure a file really doesn't exist when a `DELETED` event is generated; (b) a larger fix that adds more hierarchical structure to the index map---two levels instead of one level---to address performance issues.