### PR TITLE
Refactor tests

### DIFF
--- a/src/main/java/engineering/swat/watch/WatchEvent.java
+++ b/src/main/java/engineering/swat/watch/WatchEvent.java
@@ -27,6 +27,7 @@
 package engineering.swat.watch;
 
 import java.nio.file.Path;
+import java.util.Objects;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -126,4 +127,22 @@ public class WatchEvent {
         return String.format("WatchEvent[%s, %s, %s]", this.rootPath, this.kind, this.relativePath);
     }
 
+    /**
+     * <p>
+     * Tests the equivalence of two events. Two events are equivalent when they
+     * have equal kinds, equal root paths, and equal relative paths.
+     *
+     * <p>
+     * Note: This method applies different logic to compare events than (the
+     * default implementation of) method {@link #equals(Object)}, which
+     * shouldn't be overridden. This is because events should norminally be
+     * compared in terms of their identities (e.g., two successive modifications
+     * of the same file result in events that are equivalent, but not equal;
+     * they need to be distinguishable in collections).
+     */
+    public static boolean areEquivalent(WatchEvent e1, WatchEvent e2) {
+        return Objects.equals(e1.getKind(), e2.getKind()) &&
+            Objects.equals(e1.getRootPath(), e2.getRootPath()) &&
+            Objects.equals(e1.getRelativePath(), e2.getRelativePath());
+    }
 }

--- a/src/main/java/engineering/swat/watch/WatchEvent.java
+++ b/src/main/java/engineering/swat/watch/WatchEvent.java
@@ -131,6 +131,7 @@ public class WatchEvent {
      * <p>
      * Tests the equivalence of two events. Two events are equivalent when they
      * have equal kinds, equal root paths, and equal relative paths.
+     * </p>
      *
      * <p>
      * Note: This method applies different logic to compare events than (the
@@ -139,6 +140,7 @@ public class WatchEvent {
      * compared in terms of their identities (e.g., two successive modifications
      * of the same file result in events that are equivalent, but not equal;
      * they need to be distinguishable in collections).
+     * </p>
      */
     public static boolean areEquivalent(WatchEvent e1, WatchEvent e2) {
         return Objects.equals(e1.getKind(), e2.getKind()) &&

--- a/src/main/java/engineering/swat/watch/WatchEvent.java
+++ b/src/main/java/engineering/swat/watch/WatchEvent.java
@@ -135,7 +135,7 @@ public class WatchEvent {
      * <p>
      * Note: This method applies different logic to compare events than (the
      * default implementation of) method {@link #equals(Object)}, which
-     * shouldn't be overridden. This is because events should norminally be
+     * shouldn't be overridden. This is because events should normally be
      * compared in terms of their identities (e.g., two successive modifications
      * of the same file result in events that are equivalent, but not equal;
      * they need to be distinguishable in collections).

--- a/src/test/java/engineering/swat/watch/TestHelper.java
+++ b/src/test/java/engineering/swat/watch/TestHelper.java
@@ -82,6 +82,10 @@ public class TestHelper {
     public static class Bookkeeper implements Consumer<WatchEvent> {
         private final Queue<WatchEvent> events = new ConcurrentLinkedQueue<>();
 
+        public void reset() {
+            events.clear();
+        }
+
         public Events events() {
             return new Events(events.stream());
         }

--- a/src/test/java/engineering/swat/watch/TestHelper.java
+++ b/src/test/java/engineering/swat/watch/TestHelper.java
@@ -102,7 +102,7 @@ public class TestHelper {
             }
 
             public boolean any() {
-                return stream.anyMatch(e -> true);
+                return stream.findAny().isPresent();
             }
 
             public boolean any(WatchEvent event) {
@@ -110,11 +110,11 @@ public class TestHelper {
             }
 
             public boolean none() {
-                return stream.noneMatch(e -> true);
+                return !any();
             }
 
             public boolean none(WatchEvent event) {
-                return stream.noneMatch(e -> WatchEvent.areEquivalent(e, event));
+                return !any(event);
             }
 
             public Events kind(WatchEvent.Kind... kinds) {

--- a/src/test/java/engineering/swat/watch/TestHelper.java
+++ b/src/test/java/engineering/swat/watch/TestHelper.java
@@ -79,6 +79,10 @@ public class TestHelper {
         }
     }
 
+    /**
+     * Helper class to keep track of a list of events and query it (on a
+     * slightly higher level of abstraction than manipulation of event streams).
+     */
     public static class Bookkeeper implements Consumer<WatchEvent> {
         private final Queue<WatchEvent> events = new ConcurrentLinkedQueue<>();
 


### PR DESCRIPTION
In #20, a number of tests were added for overflow handling. The bookkeeping code to keep track of actual events vs. expected events in those tests had two issues: (a) two tests still used counting of events, which can be unreliable; (b) a few other tests had roughly the same bookkeeping code duplicated.

This PR fixes these issues by adding a general `Bookkeeping` class that is: (a) not based on counting; (b) reused across tests.