### PR TITLE
Refactored top level name of the watcher function

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Start using java-watch:
 
 ```java
 var directory = Path.of("tmp", "test-dir");
-var watcherSetup = Watcher.watch(directory, WatchScope.PATH_AND_CHILDREN)
+var watcherSetup = Watcher.build(directory, WatchScope.PATH_AND_CHILDREN)
     .withExecutor(Executors.newCachedThreadPool()) // optionally configure a custom thread pool
     .onOverflow(Approximation.DIFF) // optionally configure a handler for overflows
     .on(watchEvent -> {

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Start using java-watch:
 
 ```java
 var directory = Path.of("tmp", "test-dir");
-var watcherSetup = Watcher.build(directory, WatchScope.PATH_AND_CHILDREN)
+var watcherSetup = Watch.build(directory, WatchScope.PATH_AND_CHILDREN)
     .withExecutor(Executors.newCachedThreadPool()) // optionally configure a custom thread pool
     .onOverflow(Approximation.DIFF) // optionally configure a handler for overflows
     .on(watchEvent -> {

--- a/src/main/java/engineering/swat/watch/Watch.java
+++ b/src/main/java/engineering/swat/watch/Watch.java
@@ -53,7 +53,7 @@ import engineering.swat.watch.impl.overflows.MemorylessRescanner;
  * <p>It will avoid common errors using the raw apis, and will try to use the most native api where possible.</p>
  * Note, there are differences per platform that cannot be avoided, please review the readme of the library.
  */
-public class Watcher {
+public class Watch {
     private final Logger logger = LogManager.getLogger();
     private final Path path;
     private final WatchScope scope;
@@ -65,19 +65,9 @@ public class Watcher {
     private static final Predicate<WatchEvent> TRUE_FILTER = e -> true;
     private volatile Predicate<WatchEvent> eventFilter = TRUE_FILTER;
 
-    private Watcher(Path path, WatchScope scope) {
+    private Watch(Path path, WatchScope scope) {
         this.path = path;
         this.scope = scope;
-    }
-
-    /**
-     * Watch a path for updates, optionally also get events for its children/descendants
-     * @deprecated please upgrade to {@linkplain #build}
-     *
-     */
-    @Deprecated(since = "0.6.0", forRemoval = true)
-    public static Watcher watch(Path path, WatchScope scope) {
-        return build(path, scope);
     }
 
     /**
@@ -86,7 +76,7 @@ public class Watcher {
      * @param scope for directories you can also choose to monitor it's direct children or all it's descendants
      * @throws IllegalArgumentException in case a path is not supported (in relation to the scope)
      */
-    public static Watcher build(Path path, WatchScope scope) {
+    public static Watch build(Path path, WatchScope scope) {
         if (!path.isAbsolute()) {
             throw new IllegalArgumentException("We can only watch absolute paths");
         }
@@ -105,7 +95,7 @@ public class Watcher {
             default:
                 throw new IllegalArgumentException("Unsupported scope: " + scope);
         }
-        return new Watcher(path, scope);
+        return new Watch(path, scope);
     }
 
     /**
@@ -115,7 +105,7 @@ public class Watcher {
      * @param eventHandler a callback that handles the watch event, will be called once per event.
      * @return this for optional method chaining
      */
-    public Watcher on(Consumer<WatchEvent> eventHandler) {
+    public Watch on(Consumer<WatchEvent> eventHandler) {
         if (this.eventHandler != EMPTY_HANDLER) {
             throw new IllegalArgumentException("on handler cannot be set more than once");
         }
@@ -126,7 +116,7 @@ public class Watcher {
     /**
      * Convenience variant of {@link #on(Consumer)}, which allows you to only respond to certain events
      */
-    public Watcher on(WatchEventListener listener) {
+    public Watch on(WatchEventListener listener) {
         if (this.eventHandler != EMPTY_HANDLER) {
             throw new IllegalArgumentException("on handler cannot be set more than once");
         }
@@ -159,7 +149,7 @@ public class Watcher {
      * ({@code true}) or dropped ({@code false})
      * @return {@code this} (to support method chaining)
      */
-    Watcher filter(Predicate<WatchEvent> predicate) {
+    Watch filter(Predicate<WatchEvent> predicate) {
         if (this.eventFilter != TRUE_FILTER) {
             throw new IllegalArgumentException("filter cannot be set more than once");
         }
@@ -173,7 +163,7 @@ public class Watcher {
      * @param callbackHandler worker pool to use
      * @return this for optional method chaining
      */
-    public Watcher withExecutor(Executor callbackHandler) {
+    public Watch withExecutor(Executor callbackHandler) {
         this.executor = callbackHandler;
         return this;
     }
@@ -189,7 +179,7 @@ public class Watcher {
      * files/directories to approximate
      * @return This watcher for optional method chaining
      */
-    public Watcher onOverflow(Approximation whichFiles) {
+    public Watch onOverflow(Approximation whichFiles) {
         this.approximateOnOverflow = whichFiles;
         return this;
     }

--- a/src/main/java/engineering/swat/watch/Watcher.java
+++ b/src/main/java/engineering/swat/watch/Watcher.java
@@ -72,11 +72,21 @@ public class Watcher {
 
     /**
      * Watch a path for updates, optionally also get events for its children/descendants
+     * @deprecated please upgrade to {@linkplain #build}
+     *
+     */
+    @Deprecated(since = "0.6.0", forRemoval = true)
+    public static Watcher watch(Path path, WatchScope scope) {
+        return build(path, scope);
+    }
+
+    /**
+     * Watch a path for updates, optionally also get events for its children/descendants
      * @param path which absolute path to monitor, can be a file or a directory, but has to be absolute
      * @param scope for directories you can also choose to monitor it's direct children or all it's descendants
      * @throws IllegalArgumentException in case a path is not supported (in relation to the scope)
      */
-    public static Watcher watch(Path path, WatchScope scope) {
+    public static Watcher build(Path path, WatchScope scope) {
         if (!path.isAbsolute()) {
             throw new IllegalArgumentException("We can only watch absolute paths");
         }

--- a/src/test/java/engineering/swat/watch/APIErrorsTests.java
+++ b/src/test/java/engineering/swat/watch/APIErrorsTests.java
@@ -61,7 +61,7 @@ class APIErrorsTests {
     @Test
     void noDuplicateEvents() {
         assertThrowsExactly(IllegalArgumentException.class, () ->
-            Watcher
+            Watch
                 .build(testDir.getTestDirectory(), WatchScope.PATH_AND_CHILDREN)
                 .on(System.out::println)
                 .on(System.err::println)
@@ -71,7 +71,7 @@ class APIErrorsTests {
     @Test
     void onlyDirectoryWatchingOnDirectories() {
         assertThrowsExactly(IllegalArgumentException.class, () ->
-            Watcher
+            Watch
                 .build(testDir.getTestFiles().get(0), WatchScope.PATH_AND_CHILDREN)
         );
     }
@@ -79,7 +79,7 @@ class APIErrorsTests {
     @Test
     void doNotStartWithoutEventHandler() {
         assertThrowsExactly(IllegalStateException.class, () ->
-            Watcher
+            Watch
                 .build(testDir.getTestDirectory(), WatchScope.PATH_AND_CHILDREN)
                 .start()
         );
@@ -90,7 +90,7 @@ class APIErrorsTests {
         var relativePath = testDir.getTestDirectory().resolve("d1").relativize(testDir.getTestDirectory());
 
         assertThrowsExactly(IllegalArgumentException.class, () ->
-            Watcher
+            Watch
                 .build(relativePath, WatchScope.PATH_AND_CHILDREN)
                 .start()
         );
@@ -100,7 +100,7 @@ class APIErrorsTests {
     void nonExistingDirectory() throws IOException {
         var nonExistingDir = testDir.getTestDirectory().resolve("testd1");
         Files.createDirectory(nonExistingDir);
-        var w = Watcher.build(nonExistingDir, WatchScope.PATH_AND_CHILDREN);
+        var w = Watch.build(nonExistingDir, WatchScope.PATH_AND_CHILDREN);
         Files.delete(nonExistingDir);
         assertThrowsExactly(IllegalStateException.class, w::start);
     }

--- a/src/test/java/engineering/swat/watch/APIErrorsTests.java
+++ b/src/test/java/engineering/swat/watch/APIErrorsTests.java
@@ -62,7 +62,7 @@ class APIErrorsTests {
     void noDuplicateEvents() {
         assertThrowsExactly(IllegalArgumentException.class, () ->
             Watcher
-                .watch(testDir.getTestDirectory(), WatchScope.PATH_AND_CHILDREN)
+                .build(testDir.getTestDirectory(), WatchScope.PATH_AND_CHILDREN)
                 .on(System.out::println)
                 .on(System.err::println)
         );
@@ -72,7 +72,7 @@ class APIErrorsTests {
     void onlyDirectoryWatchingOnDirectories() {
         assertThrowsExactly(IllegalArgumentException.class, () ->
             Watcher
-                .watch(testDir.getTestFiles().get(0), WatchScope.PATH_AND_CHILDREN)
+                .build(testDir.getTestFiles().get(0), WatchScope.PATH_AND_CHILDREN)
         );
     }
 
@@ -80,7 +80,7 @@ class APIErrorsTests {
     void doNotStartWithoutEventHandler() {
         assertThrowsExactly(IllegalStateException.class, () ->
             Watcher
-                .watch(testDir.getTestDirectory(), WatchScope.PATH_AND_CHILDREN)
+                .build(testDir.getTestDirectory(), WatchScope.PATH_AND_CHILDREN)
                 .start()
         );
     }
@@ -91,7 +91,7 @@ class APIErrorsTests {
 
         assertThrowsExactly(IllegalArgumentException.class, () ->
             Watcher
-                .watch(relativePath, WatchScope.PATH_AND_CHILDREN)
+                .build(relativePath, WatchScope.PATH_AND_CHILDREN)
                 .start()
         );
     }
@@ -100,7 +100,7 @@ class APIErrorsTests {
     void nonExistingDirectory() throws IOException {
         var nonExistingDir = testDir.getTestDirectory().resolve("testd1");
         Files.createDirectory(nonExistingDir);
-        var w = Watcher.watch(nonExistingDir, WatchScope.PATH_AND_CHILDREN);
+        var w = Watcher.build(nonExistingDir, WatchScope.PATH_AND_CHILDREN);
         Files.delete(nonExistingDir);
         assertThrowsExactly(IllegalStateException.class, w::start);
     }

--- a/src/test/java/engineering/swat/watch/DeleteLockTests.java
+++ b/src/test/java/engineering/swat/watch/DeleteLockTests.java
@@ -76,7 +76,7 @@ class DeleteLockTests {
     }
 
     private void deleteAndVerify(Path target, WatchScope scope) throws IOException {
-        try (var watch = Watcher.watch(target, scope).on(ev -> {}).start()) {
+        try (var watch = Watcher.build(target, scope).on(ev -> {}).start()) {
             recursiveDelete(target);
             assertFalse(Files.exists(target), "The file/directory shouldn't exist anymore");
         }

--- a/src/test/java/engineering/swat/watch/DeleteLockTests.java
+++ b/src/test/java/engineering/swat/watch/DeleteLockTests.java
@@ -76,7 +76,7 @@ class DeleteLockTests {
     }
 
     private void deleteAndVerify(Path target, WatchScope scope) throws IOException {
-        try (var watch = Watcher.build(target, scope).on(ev -> {}).start()) {
+        try (var watch = Watch.build(target, scope).on(ev -> {}).start()) {
             recursiveDelete(target);
             assertFalse(Files.exists(target), "The file/directory shouldn't exist anymore");
         }

--- a/src/test/java/engineering/swat/watch/RecursiveWatchTests.java
+++ b/src/test/java/engineering/swat/watch/RecursiveWatchTests.java
@@ -77,7 +77,7 @@ class RecursiveWatchTests {
         var target = new AtomicReference<Path>();
         var created = new AtomicBoolean(false);
         var changed = new AtomicBoolean(false);
-        var watchConfig = Watcher.watch(testDir.getTestDirectory(), WatchScope.PATH_AND_ALL_DESCENDANTS)
+        var watchConfig = Watcher.build(testDir.getTestDirectory(), WatchScope.PATH_AND_ALL_DESCENDANTS)
             .on(ev -> {
                     logger.debug("Event received: {}", ev);
                     if (ev.calculateFullPath().equals(target.get())) {
@@ -109,7 +109,7 @@ class RecursiveWatchTests {
     void correctRelativePathIsReported() throws IOException {
         Path relative = Path.of("a","b", "c", "d.txt");
         var seen = new AtomicBoolean(false);
-        var watcher = Watcher.watch(testDir.getTestDirectory(), WatchScope.PATH_AND_ALL_DESCENDANTS)
+        var watcher = Watcher.build(testDir.getTestDirectory(), WatchScope.PATH_AND_ALL_DESCENDANTS)
             .on(ev -> {
                 logger.debug("Seen event: {}", ev);
                 if (ev.getRelativePath().equals(relative)) {
@@ -134,7 +134,7 @@ class RecursiveWatchTests {
             .findAny()
             .orElseThrow();
         var seen = new AtomicBoolean(false);
-        var watchConfig = Watcher.watch(target.getParent(), WatchScope.PATH_AND_CHILDREN)
+        var watchConfig = Watcher.build(target.getParent(), WatchScope.PATH_AND_CHILDREN)
             .on(ev -> {
                 if (ev.getKind() == Kind.DELETED && ev.calculateFullPath().equals(target)) {
                     seen.set(true);
@@ -160,7 +160,7 @@ class RecursiveWatchTests {
         // Configure and start watch
         var dropEvents = new AtomicBoolean(false); // Toggles overflow simulation
         var bookkeeper = new TestHelper.Bookkeeper();
-        var watchConfig = Watcher.watch(parent, WatchScope.PATH_AND_ALL_DESCENDANTS)
+        var watchConfig = Watcher.build(parent, WatchScope.PATH_AND_ALL_DESCENDANTS)
             .withExecutor(ForkJoinPool.commonPool())
             .filter(e -> !dropEvents.get())
             .onOverflow(whichFiles)

--- a/src/test/java/engineering/swat/watch/RecursiveWatchTests.java
+++ b/src/test/java/engineering/swat/watch/RecursiveWatchTests.java
@@ -77,7 +77,7 @@ class RecursiveWatchTests {
         var target = new AtomicReference<Path>();
         var created = new AtomicBoolean(false);
         var changed = new AtomicBoolean(false);
-        var watchConfig = Watcher.build(testDir.getTestDirectory(), WatchScope.PATH_AND_ALL_DESCENDANTS)
+        var watchConfig = Watch.build(testDir.getTestDirectory(), WatchScope.PATH_AND_ALL_DESCENDANTS)
             .on(ev -> {
                     logger.debug("Event received: {}", ev);
                     if (ev.calculateFullPath().equals(target.get())) {
@@ -109,7 +109,7 @@ class RecursiveWatchTests {
     void correctRelativePathIsReported() throws IOException {
         Path relative = Path.of("a","b", "c", "d.txt");
         var seen = new AtomicBoolean(false);
-        var watcher = Watcher.build(testDir.getTestDirectory(), WatchScope.PATH_AND_ALL_DESCENDANTS)
+        var watcher = Watch.build(testDir.getTestDirectory(), WatchScope.PATH_AND_ALL_DESCENDANTS)
             .on(ev -> {
                 logger.debug("Seen event: {}", ev);
                 if (ev.getRelativePath().equals(relative)) {
@@ -134,7 +134,7 @@ class RecursiveWatchTests {
             .findAny()
             .orElseThrow();
         var seen = new AtomicBoolean(false);
-        var watchConfig = Watcher.build(target.getParent(), WatchScope.PATH_AND_CHILDREN)
+        var watchConfig = Watch.build(target.getParent(), WatchScope.PATH_AND_CHILDREN)
             .on(ev -> {
                 if (ev.getKind() == Kind.DELETED && ev.calculateFullPath().equals(target)) {
                     seen.set(true);
@@ -160,7 +160,7 @@ class RecursiveWatchTests {
         // Configure and start watch
         var dropEvents = new AtomicBoolean(false); // Toggles overflow simulation
         var bookkeeper = new TestHelper.Bookkeeper();
-        var watchConfig = Watcher.build(parent, WatchScope.PATH_AND_ALL_DESCENDANTS)
+        var watchConfig = Watch.build(parent, WatchScope.PATH_AND_ALL_DESCENDANTS)
             .withExecutor(ForkJoinPool.commonPool())
             .filter(e -> !dropEvents.get())
             .onOverflow(whichFiles)

--- a/src/test/java/engineering/swat/watch/SingleDirectoryTests.java
+++ b/src/test/java/engineering/swat/watch/SingleDirectoryTests.java
@@ -71,7 +71,7 @@ class SingleDirectoryTests {
         var target = testDir.getTestFiles().get(0);
         var seenDelete = new AtomicBoolean(false);
         var seenCreate = new AtomicBoolean(false);
-        var watchConfig = Watcher.build(target.getParent(), WatchScope.PATH_AND_CHILDREN)
+        var watchConfig = Watch.build(target.getParent(), WatchScope.PATH_AND_CHILDREN)
             .on(ev -> {
                 if (ev.getKind() == Kind.DELETED && ev.calculateFullPath().equals(target)) {
                     seenDelete.set(true);
@@ -99,7 +99,7 @@ class SingleDirectoryTests {
         var target = testDir.getTestFiles().get(0);
         var seenDelete = new AtomicBoolean(false);
         var seenCreate = new AtomicBoolean(false);
-        var watchConfig = Watcher.build(target.getParent(), WatchScope.PATH_AND_CHILDREN)
+        var watchConfig = Watch.build(target.getParent(), WatchScope.PATH_AND_CHILDREN)
             .on(new WatchEventListener() {
                 @Override
                 public void onCreated(WatchEvent ev) {
@@ -132,7 +132,7 @@ class SingleDirectoryTests {
         Files.writeString(directory.resolve("b.txt"), "bar");
 
         var bookkeeper = new TestHelper.Bookkeeper();
-        var watchConfig = Watcher.build(directory, WatchScope.PATH_AND_CHILDREN)
+        var watchConfig = Watch.build(directory, WatchScope.PATH_AND_CHILDREN)
             .onOverflow(Approximation.ALL)
             .on(bookkeeper);
 
@@ -169,7 +169,7 @@ class SingleDirectoryTests {
 
         var bookkeeper = new TestHelper.Bookkeeper();
         var dropEvents = new AtomicBoolean(false); // Toggles overflow simulation
-        var watchConfig = Watcher.build(directory, WatchScope.PATH_AND_CHILDREN)
+        var watchConfig = Watch.build(directory, WatchScope.PATH_AND_CHILDREN)
             .filter(e -> !dropEvents.get())
             .onOverflow(Approximation.DIFF)
             .on(bookkeeper);

--- a/src/test/java/engineering/swat/watch/SingleDirectoryTests.java
+++ b/src/test/java/engineering/swat/watch/SingleDirectoryTests.java
@@ -71,7 +71,7 @@ class SingleDirectoryTests {
         var target = testDir.getTestFiles().get(0);
         var seenDelete = new AtomicBoolean(false);
         var seenCreate = new AtomicBoolean(false);
-        var watchConfig = Watcher.watch(target.getParent(), WatchScope.PATH_AND_CHILDREN)
+        var watchConfig = Watcher.build(target.getParent(), WatchScope.PATH_AND_CHILDREN)
             .on(ev -> {
                 if (ev.getKind() == Kind.DELETED && ev.calculateFullPath().equals(target)) {
                     seenDelete.set(true);
@@ -99,7 +99,7 @@ class SingleDirectoryTests {
         var target = testDir.getTestFiles().get(0);
         var seenDelete = new AtomicBoolean(false);
         var seenCreate = new AtomicBoolean(false);
-        var watchConfig = Watcher.watch(target.getParent(), WatchScope.PATH_AND_CHILDREN)
+        var watchConfig = Watcher.build(target.getParent(), WatchScope.PATH_AND_CHILDREN)
             .on(new WatchEventListener() {
                 @Override
                 public void onCreated(WatchEvent ev) {
@@ -132,7 +132,7 @@ class SingleDirectoryTests {
         Files.writeString(directory.resolve("b.txt"), "bar");
 
         var bookkeeper = new TestHelper.Bookkeeper();
-        var watchConfig = Watcher.watch(directory, WatchScope.PATH_AND_CHILDREN)
+        var watchConfig = Watcher.build(directory, WatchScope.PATH_AND_CHILDREN)
             .onOverflow(Approximation.ALL)
             .on(bookkeeper);
 
@@ -169,7 +169,7 @@ class SingleDirectoryTests {
 
         var bookkeeper = new TestHelper.Bookkeeper();
         var dropEvents = new AtomicBoolean(false); // Toggles overflow simulation
-        var watchConfig = Watcher.watch(directory, WatchScope.PATH_AND_CHILDREN)
+        var watchConfig = Watcher.build(directory, WatchScope.PATH_AND_CHILDREN)
             .filter(e -> !dropEvents.get())
             .onOverflow(Approximation.DIFF)
             .on(bookkeeper);

--- a/src/test/java/engineering/swat/watch/SingleFileTests.java
+++ b/src/test/java/engineering/swat/watch/SingleFileTests.java
@@ -71,7 +71,7 @@ class SingleFileTests {
         var target = testDir.getTestFiles().get(0);
         var seen = new AtomicBoolean(false);
         var others = new AtomicBoolean(false);
-        var watchConfig = Watcher.build(target, WatchScope.PATH_ONLY)
+        var watchConfig = Watch.build(target, WatchScope.PATH_ONLY)
             .on(ev -> {
                 if (ev.calculateFullPath().equals(target)) {
                     seen.set(true);
@@ -100,7 +100,7 @@ class SingleFileTests {
         var target = testDir.getTestDirectory();
         var seen = new AtomicBoolean(false);
         var others = new AtomicBoolean(false);
-        var watchConfig = Watcher.build(target, WatchScope.PATH_ONLY)
+        var watchConfig = Watch.build(target, WatchScope.PATH_ONLY)
             .on(ev -> {
                 if (ev.calculateFullPath().equals(target)) {
                     seen.set(true);
@@ -161,7 +161,7 @@ class SingleFileTests {
         var parent = testDir.getTestDirectory();
         var file = parent.resolve("a.txt");
 
-        var watch = Watcher
+        var watch = Watch
             .build(file, WatchScope.PATH_ONLY)
             .onOverflow(whichFiles)
             .on(bookkeeper)

--- a/src/test/java/engineering/swat/watch/SingleFileTests.java
+++ b/src/test/java/engineering/swat/watch/SingleFileTests.java
@@ -71,7 +71,7 @@ class SingleFileTests {
         var target = testDir.getTestFiles().get(0);
         var seen = new AtomicBoolean(false);
         var others = new AtomicBoolean(false);
-        var watchConfig = Watcher.watch(target, WatchScope.PATH_ONLY)
+        var watchConfig = Watcher.build(target, WatchScope.PATH_ONLY)
             .on(ev -> {
                 if (ev.calculateFullPath().equals(target)) {
                     seen.set(true);
@@ -100,7 +100,7 @@ class SingleFileTests {
         var target = testDir.getTestDirectory();
         var seen = new AtomicBoolean(false);
         var others = new AtomicBoolean(false);
-        var watchConfig = Watcher.watch(target, WatchScope.PATH_ONLY)
+        var watchConfig = Watcher.build(target, WatchScope.PATH_ONLY)
             .on(ev -> {
                 if (ev.calculateFullPath().equals(target)) {
                     seen.set(true);
@@ -162,7 +162,7 @@ class SingleFileTests {
         var file = parent.resolve("a.txt");
 
         var watch = Watcher
-            .watch(file, WatchScope.PATH_ONLY)
+            .build(file, WatchScope.PATH_ONLY)
             .onOverflow(whichFiles)
             .on(bookkeeper)
             .start();

--- a/src/test/java/engineering/swat/watch/SmokeTests.java
+++ b/src/test/java/engineering/swat/watch/SmokeTests.java
@@ -65,7 +65,7 @@ class SmokeTests {
     void watchDirectory() throws IOException {
         var changed = new AtomicBoolean(false);
         var target = testDir.getTestFiles().get(0);
-        var watchConfig = Watcher.build(testDir.getTestDirectory(), WatchScope.PATH_AND_CHILDREN)
+        var watchConfig = Watch.build(testDir.getTestDirectory(), WatchScope.PATH_AND_CHILDREN)
             .on(ev -> {if (ev.getKind() == MODIFIED && ev.calculateFullPath().equals(target)) { changed.set(true); }})
             ;
 
@@ -82,7 +82,7 @@ class SmokeTests {
             .filter(p -> !p.getParent().equals(testDir.getTestDirectory()))
             .findFirst()
             .orElseThrow();
-        var watchConfig = Watcher.build(testDir.getTestDirectory(), WatchScope.PATH_AND_ALL_DESCENDANTS)
+        var watchConfig = Watch.build(testDir.getTestDirectory(), WatchScope.PATH_AND_ALL_DESCENDANTS)
             .on(ev -> { if (ev.getKind() == MODIFIED && ev.calculateFullPath().equals(target)) { changed.set(true);}})
             ;
 
@@ -100,7 +100,7 @@ class SmokeTests {
             .findFirst()
             .orElseThrow();
 
-        var watchConfig = Watcher.build(target, WatchScope.PATH_ONLY)
+        var watchConfig = Watch.build(target, WatchScope.PATH_ONLY)
             .on(ev -> {
                 if (ev.calculateFullPath().equals(target)) {
                     changed.set(true);

--- a/src/test/java/engineering/swat/watch/SmokeTests.java
+++ b/src/test/java/engineering/swat/watch/SmokeTests.java
@@ -65,7 +65,7 @@ class SmokeTests {
     void watchDirectory() throws IOException {
         var changed = new AtomicBoolean(false);
         var target = testDir.getTestFiles().get(0);
-        var watchConfig = Watcher.watch(testDir.getTestDirectory(), WatchScope.PATH_AND_CHILDREN)
+        var watchConfig = Watcher.build(testDir.getTestDirectory(), WatchScope.PATH_AND_CHILDREN)
             .on(ev -> {if (ev.getKind() == MODIFIED && ev.calculateFullPath().equals(target)) { changed.set(true); }})
             ;
 
@@ -82,7 +82,7 @@ class SmokeTests {
             .filter(p -> !p.getParent().equals(testDir.getTestDirectory()))
             .findFirst()
             .orElseThrow();
-        var watchConfig = Watcher.watch(testDir.getTestDirectory(), WatchScope.PATH_AND_ALL_DESCENDANTS)
+        var watchConfig = Watcher.build(testDir.getTestDirectory(), WatchScope.PATH_AND_ALL_DESCENDANTS)
             .on(ev -> { if (ev.getKind() == MODIFIED && ev.calculateFullPath().equals(target)) { changed.set(true);}})
             ;
 
@@ -100,7 +100,7 @@ class SmokeTests {
             .findFirst()
             .orElseThrow();
 
-        var watchConfig = Watcher.watch(target, WatchScope.PATH_ONLY)
+        var watchConfig = Watcher.build(target, WatchScope.PATH_ONLY)
             .on(ev -> {
                 if (ev.calculateFullPath().equals(target)) {
                     changed.set(true);

--- a/src/test/java/engineering/swat/watch/TortureTests.java
+++ b/src/test/java/engineering/swat/watch/TortureTests.java
@@ -153,7 +153,7 @@ class TortureTests {
         var io = new IOGenerator(THREADS, root, pool);
 
         var seenCreates = ConcurrentHashMap.<Path>newKeySet();
-        var watchConfig = Watcher.watch(testDir.getTestDirectory(), WatchScope.PATH_AND_ALL_DESCENDANTS)
+        var watchConfig = Watcher.build(testDir.getTestDirectory(), WatchScope.PATH_AND_ALL_DESCENDANTS)
             .withExecutor(pool)
             .onOverflow(whichFiles)
             .on(ev -> {
@@ -223,7 +223,7 @@ class TortureTests {
             var r = new Thread(() -> {
                 try {
                     var watcher = Watcher
-                        .watch(testDir.getTestDirectory(), WatchScope.PATH_AND_CHILDREN)
+                        .build(testDir.getTestDirectory(), WatchScope.PATH_AND_CHILDREN)
                         .on(e -> seen.add(e.calculateFullPath()));
                     startRegistering.acquire();
                     try (var c = watcher.start()) {
@@ -295,7 +295,7 @@ class TortureTests {
                         startRegistering.acquire();
                         for (int k = 0; k < 1000; k++) {
                             var watcher = Watcher
-                                .watch(testDir.getTestDirectory(), WatchScope.PATH_AND_CHILDREN)
+                                .build(testDir.getTestDirectory(), WatchScope.PATH_AND_CHILDREN)
                                 .onOverflow(whichFiles)
                                 .on(e -> {
                                     if (e.calculateFullPath().equals(target)) {
@@ -359,7 +359,7 @@ class TortureTests {
 
             final var events = new AtomicInteger(0);
             final var happened = new Semaphore(0);
-            var watchConfig = Watcher.watch(testDir.getTestDirectory(), WatchScope.PATH_AND_ALL_DESCENDANTS)
+            var watchConfig = Watcher.build(testDir.getTestDirectory(), WatchScope.PATH_AND_ALL_DESCENDANTS)
                 .withExecutor(pool)
                 .onOverflow(whichFiles)
                 .on(ev -> {

--- a/src/test/java/engineering/swat/watch/TortureTests.java
+++ b/src/test/java/engineering/swat/watch/TortureTests.java
@@ -153,7 +153,7 @@ class TortureTests {
         var io = new IOGenerator(THREADS, root, pool);
 
         var seenCreates = ConcurrentHashMap.<Path>newKeySet();
-        var watchConfig = Watcher.build(testDir.getTestDirectory(), WatchScope.PATH_AND_ALL_DESCENDANTS)
+        var watchConfig = Watch.build(testDir.getTestDirectory(), WatchScope.PATH_AND_ALL_DESCENDANTS)
             .withExecutor(pool)
             .onOverflow(whichFiles)
             .on(ev -> {
@@ -222,7 +222,7 @@ class TortureTests {
         for (int t = 0; t < TORTURE_REGISTRATION_THREADS; t++) {
             var r = new Thread(() -> {
                 try {
-                    var watcher = Watcher
+                    var watcher = Watch
                         .build(testDir.getTestDirectory(), WatchScope.PATH_AND_CHILDREN)
                         .on(e -> seen.add(e.calculateFullPath()));
                     startRegistering.acquire();
@@ -294,7 +294,7 @@ class TortureTests {
                         var id = Thread.currentThread().getId();
                         startRegistering.acquire();
                         for (int k = 0; k < 1000; k++) {
-                            var watcher = Watcher
+                            var watcher = Watch
                                 .build(testDir.getTestDirectory(), WatchScope.PATH_AND_CHILDREN)
                                 .onOverflow(whichFiles)
                                 .on(e -> {
@@ -359,7 +359,7 @@ class TortureTests {
 
             final var events = new AtomicInteger(0);
             final var happened = new Semaphore(0);
-            var watchConfig = Watcher.build(testDir.getTestDirectory(), WatchScope.PATH_AND_ALL_DESCENDANTS)
+            var watchConfig = Watch.build(testDir.getTestDirectory(), WatchScope.PATH_AND_ALL_DESCENDANTS)
                 .withExecutor(pool)
                 .onOverflow(whichFiles)
                 .on(ev -> {

--- a/src/test/java/engineering/swat/watch/impl/overflows/IndexingRescannerTests.java
+++ b/src/test/java/engineering/swat/watch/impl/overflows/IndexingRescannerTests.java
@@ -74,7 +74,7 @@ class IndexingRescannerTests {
         // Configure a non-recursive directory watch that monitors only the
         // children (not all descendants) of `path`
         var eventsOnlyForChildren = new AtomicBoolean(true);
-        var watchConfig = Watcher.watch(path, WatchScope.PATH_AND_CHILDREN)
+        var watchConfig = Watcher.build(path, WatchScope.PATH_AND_CHILDREN)
             .onOverflow(Approximation.NONE) // Disable the auto-handler here; we'll have an explicit one below
             .on(e -> {
                 if (e.getRelativePath().getNameCount() > 1) {

--- a/src/test/java/engineering/swat/watch/impl/overflows/IndexingRescannerTests.java
+++ b/src/test/java/engineering/swat/watch/impl/overflows/IndexingRescannerTests.java
@@ -43,7 +43,7 @@ import engineering.swat.watch.TestDirectory;
 import engineering.swat.watch.TestHelper;
 import engineering.swat.watch.WatchEvent;
 import engineering.swat.watch.WatchScope;
-import engineering.swat.watch.Watcher;
+import engineering.swat.watch.Watch;
 import engineering.swat.watch.impl.EventHandlingWatch;
 
 class IndexingRescannerTests {
@@ -74,7 +74,7 @@ class IndexingRescannerTests {
         // Configure a non-recursive directory watch that monitors only the
         // children (not all descendants) of `path`
         var eventsOnlyForChildren = new AtomicBoolean(true);
-        var watchConfig = Watcher.build(path, WatchScope.PATH_AND_CHILDREN)
+        var watchConfig = Watch.build(path, WatchScope.PATH_AND_CHILDREN)
             .onOverflow(Approximation.NONE) // Disable the auto-handler here; we'll have an explicit one below
             .on(e -> {
                 if (e.getRelativePath().getNameCount() > 1) {


### PR DESCRIPTION
I noticed that `Watcher.watch` is a bit strange:

- `watcher.watch` looks a bit duplicate
- it doesn't actually start the watch, it's more of a builder pattern

alternatives:

- `Watcher.path`
- `Watcher.on` (but that was already the event handler)