### PR TITLE
Test for moving files

### DIFF
--- a/src/main/java/engineering/swat/watch/impl/jdk/JDKFileWatch.java
+++ b/src/main/java/engineering/swat/watch/impl/jdk/JDKFileWatch.java
@@ -61,12 +61,9 @@ public class JDKFileWatch extends JDKBaseWatch {
         assert !parent.equals(file);
 
         this.internal = new JDKDirectoryWatch(parent, exec, (w, e) -> {
-            if (e.getKind() == WatchEvent.Kind.OVERFLOW) {
-                var overflow = new WatchEvent(WatchEvent.Kind.OVERFLOW, file);
-                eventHandler.accept(w, overflow);
-            }
-            if (fileName.equals(e.getRelativePath())) {
-                eventHandler.accept(w, e);
+            var kind = e.getKind();
+            if (kind == WatchEvent.Kind.OVERFLOW || e.getRelativePath().equals(fileName)) {
+                eventHandler.accept(w, new WatchEvent(kind, file));
             }
         }, eventFilter);
 

--- a/src/test/java/engineering/swat/watch/SingleFileTests.java
+++ b/src/test/java/engineering/swat/watch/SingleFileTests.java
@@ -143,13 +143,11 @@ class SingleFileTests {
         try (var watch = startWatchAndTriggerOverflow(Approximation.ALL, bookkeeper)) {
             Thread.sleep(TestHelper.SHORT_WAIT.toMillis());
 
-            var fileName = watch.getPath().getFileName();
-            var parent = watch.getPath().getParent();
-
-            await("Overflow should trigger created event for `" + fileName + "`")
-                .until(() -> bookkeeper.events().kind(CREATED).rootPath(parent).relativePath(fileName).any());
+            var path = watch.getPath();
+            await("Overflow should trigger created event for `" + path + "`")
+                .until(() -> bookkeeper.events().kind(CREATED).rootPath(path).any());
             await("Overflow shouldn't trigger created events for other files")
-                .until(() -> bookkeeper.events().kind(CREATED).rootPath(parent).relativePathNot(fileName).none());
+                .until(() -> bookkeeper.events().kind(CREATED).rootPathNot(path).none());
             await("Overflow shouldn't trigger modified or deleted events")
                 .until(() -> bookkeeper.events().kind(MODIFIED, DELETED).none());
             await("Overflow should be visible to user-defined event handler")

--- a/src/test/java/engineering/swat/watch/SmokeTests.java
+++ b/src/test/java/engineering/swat/watch/SmokeTests.java
@@ -121,23 +121,23 @@ class SmokeTests {
         var file = Files.createFile(child1.resolve("file.txt"));
 
         var parentWatchBookkeeper = new TestHelper.Bookkeeper();
-        var parentWatchConfig = Watcher
-            .watch(parent, WatchScope.PATH_AND_ALL_DESCENDANTS)
+        var parentWatchConfig = Watch
+            .build(parent, WatchScope.PATH_AND_ALL_DESCENDANTS)
             .on(parentWatchBookkeeper);
 
         var child1WatchBookkeeper = new TestHelper.Bookkeeper();
-        var child1WatchConfig = Watcher
-            .watch(child1, WatchScope.PATH_AND_CHILDREN)
+        var child1WatchConfig = Watch
+            .build(child1, WatchScope.PATH_AND_CHILDREN)
             .on(child1WatchBookkeeper);
 
         var child2WatchBookkeeper = new TestHelper.Bookkeeper();
-        var child2WatchConfig = Watcher
-            .watch(child2, WatchScope.PATH_AND_CHILDREN)
+        var child2WatchConfig = Watch
+            .build(child2, WatchScope.PATH_AND_CHILDREN)
             .on(child2WatchBookkeeper);
 
         var fileWatchBookkeeper = new TestHelper.Bookkeeper();
-        var fileWatchConfig = Watcher
-            .watch(file, WatchScope.PATH_ONLY)
+        var fileWatchConfig = Watch
+            .build(file, WatchScope.PATH_ONLY)
             .on(fileWatchBookkeeper);
 
         try (var parentWatch = parentWatchConfig.start();

--- a/src/test/java/engineering/swat/watch/TestHelper.java
+++ b/src/test/java/engineering/swat/watch/TestHelper.java
@@ -48,7 +48,7 @@ public class TestHelper {
         var os = System.getProperty("os.name", "?").toLowerCase();
         if (os.contains("mac")) {
             // OSX is SLOW on it's watches
-            delayFactor *= 2;
+            delayFactor *= 3;
         }
         else if (os.contains("win")) {
             // windows watches can be slow to get everything


### PR DESCRIPTION
This PR:
  - adds a test to validate if file moves are properly reported;
  - fixes an issue  in `JDKFileWatch` (which coincidentally came to light because of the new test, but isn't directly related to file moves) that caused events for `foo/bar/baz.txt` to be reported as events for `foo/bar` and `baz.txt` as root path and relative path, instead of `foo/bar/baz.txt` and ` ` (empty).