### PR TITLE
From `fsevent-sys` to `objc2-core-services`

### DIFF
--- a/src/main/rust/Cargo.lock
+++ b/src/main/rust/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,47 +46,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
 name = "dispatch2"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a0d569e003ff27784e0e14e4a594048698e0c0f0b66cabcb51511be55a7caa0"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "fsevent-sys"
-version = "5.0.0"
-source = "git+https://github.com/octplane/fsevent-rust.git?rev=refs%2Fpull%2F44%2Fhead#93167444410b3576d6c49ae773becde1d6b45b37"
-dependencies = [
- "core-foundation 0.9.4",
- "dispatch2",
+ "objc2",
 ]
 
 [[package]]
@@ -121,6 +96,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "block2",
+ "dispatch2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-services"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583300ad934cba24ff5292aee751ecc070f7ca6b39a574cc21b7b5e588e06a0b"
+dependencies = [
+ "bitflags",
+ "block2",
+ "dispatch2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-security",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-security"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,10 +171,10 @@ dependencies = [
 name = "rust-fsevents-jni"
 version = "0.1.0"
 dependencies = [
- "core-foundation 0.10.1",
  "dispatch2",
- "fsevent-sys",
  "jni",
+ "objc2-core-foundation",
+ "objc2-core-services",
 ]
 
 [[package]]

--- a/src/main/rust/Cargo.toml
+++ b/src/main/rust/Cargo.toml
@@ -12,9 +12,7 @@ lto = true
 codegen-units = 1
 
 [dependencies]
-# we need this PR as it contains an updated version that targets core-foundation
-fsevent-sys = { git = "https://github.com/octplane/fsevent-rust.git", rev= "refs/pull/44/head"}
-core-foundation = "0.10.1"
-# we need this specific version of dispatch2, that still exposes the native type
-dispatch2 = { version = "0.2.0", default-features = false, features = ["alloc"] }
+objc2-core-services = "0.3.2"
+objc2-core-foundation = "0.3.2"
+dispatch2 = { version = "0.3.1", default-features = false, features = ["alloc"] }
 jni = "0.21.1"

--- a/src/main/rust/src/fs_monitor.rs
+++ b/src/main/rust/src/fs_monitor.rs
@@ -40,13 +40,9 @@ use std::{
     os::raw::{c_char, c_void},
     sync::atomic::{AtomicBool, Ordering},
 };
-use dispatch2::ffi::{dispatch_object_t, dispatch_queue_t, DISPATCH_QUEUE_SERIAL, dispatch_queue_create};
-use core_foundation::{
-    array::CFArray,
-    base::{kCFAllocatorDefault, TCFType},
-    string::CFString,
-};
-use fsevent_sys::{self as fse};
+use dispatch2::{DispatchQueue, DispatchQueueAttr, DispatchRetained};
+use objc2_core_foundation::{CFArray, CFRetained, CFString};
+use objc2_core_services::{self as fse};
 
 pub enum Kind { // Ordinals need to be consistent with enum `Kind` in Java
     OVERFLOW=0,
@@ -58,8 +54,8 @@ pub enum Kind { // Ordinals need to be consistent with enum `Kind` in Java
 pub struct NativeEventStream {
     since_when: fse::FSEventStreamEventId,
     closed: AtomicBool,
-    path : CFArray<CFString>,
-    queue: dispatch_queue_t,
+    path: CFRetained<CFArray<CFString>>,
+    queue: DispatchRetained<DispatchQueue>,
     stream: Option<fse::FSEventStreamRef>,
     info: *mut ContextInfo,
 }
@@ -69,8 +65,8 @@ impl NativeEventStream {
         Self {
             since_when: unsafe { fse::FSEventsGetCurrentEventId() },
             closed: AtomicBool::new(false),
-            path: CFArray::from_CFTypes(&[CFString::new(&path)]),
-            queue: unsafe { dispatch_queue_create(ptr::null(), DISPATCH_QUEUE_SERIAL) },
+            path: CFArray::from_retained_objects(&[CFString::from_str(&path)]),
+            queue: DispatchQueue::new("java-watch", DispatchQueueAttr::SERIAL),
             stream: None,
             info: Box::into_raw(Box::new(ContextInfo{ handler: Box::new(handler) })),
         }
@@ -79,23 +75,23 @@ impl NativeEventStream {
     pub fn start(&mut self) {
         unsafe {
             let stream = fse::FSEventStreamCreate(
-                kCFAllocatorDefault,
-                callback,
-                &fse::FSEventStreamContext {
+                None,
+                Some(callback),
+                &mut fse::FSEventStreamContext {
                     version: 0,
                     info: self.info as *mut _,
                     retain: None,
                     release: Some(release_context),
-                    copy_description: None
+                    copyDescription: None
                 },
-                self.path.as_concrete_TypeRef(),
+                self.path.as_opaque(),
                 self.since_when,
                 0.15,
                 FLAGS);
 
             self.stream = Some(stream);
 
-            fse::FSEventStreamSetDispatchQueue(stream, self.queue);
+            fse::FSEventStreamSetDispatchQueue(stream, Some(&self.queue));
             fse::FSEventStreamStart(stream);
         };
     }
@@ -107,13 +103,11 @@ impl NativeEventStream {
         match self.stream {
             Some(stream) => unsafe{
                 fse::FSEventStreamStop(stream);
-                fse::FSEventStreamSetDispatchQueue(stream, ptr::null_mut());
+                fse::FSEventStreamSetDispatchQueue(stream, None);
                 fse::FSEventStreamInvalidate(stream);
-                dispatch2::ffi::dispatch_release(self.queue as dispatch_object_t);
                 fse::FSEventStreamRelease(stream);
             }
-            None => unsafe {
-                dispatch2::ffi::dispatch_release(self.queue as dispatch_object_t);
+            None => {
             }
         };
     }
@@ -128,28 +122,28 @@ const FLAGS : fse::FSEventStreamCreateFlags
         | fse::kFSEventStreamCreateFlagWatchRoot
         | fse::kFSEventStreamCreateFlagFileEvents;
 
-extern "C" fn release_context(info: *mut c_void) {
+unsafe extern "C-unwind" fn release_context(info: *const c_void) {
   let ctx_ptr = info as *mut ContextInfo;
   unsafe{ drop(Box::from_raw( ctx_ptr)); }
 }
 
-extern "C" fn callback(
-    _stream_ref: fse::FSEventStreamRef,
+unsafe extern "C-unwind" fn callback(
+    _stream_ref: fse::ConstFSEventStreamRef,
     info: *mut c_void,
     num_events: usize,
-    event_paths: *mut c_void,
-    event_flags: *const fse::FSEventStreamEventFlags,
-    _event_ids: *const fse::FSEventStreamEventId,
+    event_paths: ptr::NonNull<c_void>,
+    event_flags: ptr::NonNull<fse::FSEventStreamEventFlags>,
+    _event_ids: ptr::NonNull<fse::FSEventStreamEventId>,
 ) {
     let info = unsafe{ &mut *(info as *mut ContextInfo) };
     let handler = info.handler.as_ref();
 
-    let event_paths = event_paths as *const *const c_char;
+    let event_paths = event_paths.as_ptr() as *const *const c_char;
     for i in 0..num_events {
         // TODO: We're currently going from C strings to Rust strings to JNI
         // strings. If possible, go directly from C strings to JNI strings.
         let path = unsafe { CStr::from_ptr(*event_paths.add(i)).to_str().unwrap().to_string() };
-        let flags: fse::FSEventStreamEventFlags = unsafe { *event_flags.add(i) };
+        let flags: fse::FSEventStreamEventFlags = unsafe { *event_flags.as_ptr().add(i) };
 
         // Note: Multiple "physical" native events might be coalesced into a
         // single "logical" native event, so the following series of checks


### PR DESCRIPTION
On macOS, we used to use Rust crate `fsevent-sys` to access native libraries. However, as of November 2025 (version `5.2.0`), that crate [is](https://github.com/octplane/fsevent-rust/pull/48) [deprecated](https://docs.rs/fsevent-sys/5.2.0/fsevent_sys/) and succeeded by crate `objc2-core-services`. This PR migrates our Rust code for macOS to that crate.

(See [comment](https://github.com/SWAT-engineering/java-watch/pull/93#issuecomment-4119041127) below for further context.)